### PR TITLE
video title

### DIFF
--- a/video_xblock/static/html/student_view.html
+++ b/video_xblock/static/html/student_view.html
@@ -1,4 +1,5 @@
 {# To avoid interferrence with other video players and JavaScript modules (e.g. RequireJS) we wrap video player's code inside an iframe. #}
+<h3 class="hd hd-2">{{display_name}}</h3>
 <iframe
     src="{{player_url}}"
     frameborder="0"

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -89,7 +89,8 @@ class VideoXBlock(StudioEditableXBlockMixin, XBlock):
         html = Template(self.resource_string('static/html/student_view.html'))
         frag = Fragment(
             html_parser.unescape(
-                html.render(Context({'player_url': player_url}))
+                html.render(Context({'player_url': player_url,
+                                     'display_name': self.display_name}))
             )
         )
         return frag


### PR DESCRIPTION
https://trello.com/c/CxIbpPYr/41-bug-lms-cms-component-display-name-video-title-does-not-show-in-lms