### PR TITLE
Progress bar markup bugfix

### DIFF
--- a/video_xblock/static/css/videojs.css
+++ b/video_xblock/static/css/videojs.css
@@ -23,6 +23,7 @@ body {
     position: absolute;
     width: 100%;
     top: -.5em;
+    left: 0;
     height: 5px;
     background: none !important;
 }


### PR DESCRIPTION
Progress bar had incorrect position on Safari and IE
https://trello.com/c/mqBhfGfO/64-wistia-youtube-ie11-and-safari-and-ff-video-position-slider