### PR TITLE
Fix pep 8 violations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ test-py:
 quality: quality-py quality-js
 
 quality-py:
-	pylint video_xblock
-	pep8 .
+	pylint -f colorized video_xblock
+	pep8 . --format=pylint --max-line-length=120
 
 quality-js:
 	eslint video_xblock/static/js/

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,16 @@ test: test-py
 test-py:
 	nosetests video_xblock --with-coverage --cover-package=video_xblock
 
-quality: quality-py quality-js
+quality: quality-py quality-js quality-pep8
 
 quality-py:
 	pylint video_xblock
 
 quality-js:
 	eslint video_xblock/static/js/
+
+quality-pep8:
+	pep8 .
 
 package:
 	echo "Here be static dependencies packaging"

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,14 @@ test: test-py
 test-py:
 	nosetests video_xblock --with-coverage --cover-package=video_xblock
 
-quality: quality-py quality-js quality-pep8
+quality: quality-py quality-js
 
 quality-py:
 	pylint video_xblock
+	pep8 .
 
 quality-js:
 	eslint video_xblock/static/js/
-
-quality-pep8:
-	pep8 .
 
 package:
 	echo "Here be static dependencies packaging"

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,5 @@ setup(
             'dummy-player = video_xblock.backends.dummy:DummyPlayer',
         ]
     },
-    package_data=package_data("video_xblock", ["static",]),
+    package_data=package_data("video_xblock", ["static", ]),
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ django==1.8.12
 edx-lint==0.5.2
 mako==1.0.2
 pylint==1.6.5
+pep8

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -236,7 +236,7 @@ class BrightcovePlayer(BaseVideoPlayer):
             transcripts_data = [
                 [el.get('src'), el.get('srclang')]
                 for el in captions_data
-                ]
+            ]
             # Populate default_transcripts
             for transcript_url, lang_code in transcripts_data:
                 lang_label = self.get_transcript_language_parameters(lang_code)[1]

--- a/video_xblock/tests/test_video_xblock.py
+++ b/video_xblock/tests/test_video_xblock.py
@@ -13,10 +13,9 @@ from xblock.field_data import DictFieldData
 from xblock.test.tools import TestRuntime
 
 from video_xblock import VideoXBlock
+from video_xblock.utils import ugettext as _
 
 settings.configure()
-
-_ = lambda text: text
 
 
 class VideoXBlockTests(unittest.TestCase):

--- a/video_xblock/tests/test_video_xblock.py
+++ b/video_xblock/tests/test_video_xblock.py
@@ -106,9 +106,9 @@ class VideoXBlockTests(unittest.TestCase):
         factory = RequestFactory()
         request = factory.post('', json.dumps(data), content_type='application/json')
         response = self.block.save_player_state(request)
-        self.assertEqual('{"success": true}', response.body) # pylint: disable=no-member
+        self.assertEqual('{"success": true}', response.body)  # pylint: disable=no-member
         self.assertDictEqual(self.block.player_state, {
-            'current_time':data['currentTime'],
+            'current_time': data['currentTime'],
             'muted': data['muted'],
             'playback_rate': data['playbackRate'],
             'volume': data['volume'],

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -1,0 +1,10 @@
+"""
+This module contains video xblock helpers.
+"""
+
+
+def ugettext(text):
+    """
+    Dummy ugettext method that doesn't do anything.
+    """
+    return text

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -471,8 +471,8 @@ class VideoXBlock(TranscriptsMixin, StudioEditableXBlockMixin, XBlock):
             video_player_id='video_player_{}'.format(self.location.block_id),  # pylint: disable=no-member
             save_state_url=save_state_url,
             player_state=self.player_state,
-            start_time=int(self.start_time.total_seconds()), # pylint: disable=no-member
-            end_time=int(self.end_time.total_seconds()), # pylint: disable=no-member
+            start_time=int(self.start_time.total_seconds()),  # pylint: disable=no-member
+            end_time=int(self.end_time.total_seconds()),  # pylint: disable=no-member
             brightcove_js_url=VideoXBlock.get_brightcove_js_url(self.account_id, self.player_id),
             transcripts=transcripts
         )

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -24,9 +24,9 @@ from webob import Response
 from .backends.base import BaseVideoPlayer, html_parser
 from .settings import ALL_LANGUAGES
 from .fields import RelativeTime
+from .utils import ugettext as _
 
 
-_ = lambda text: text
 log = logging.getLogger(__name__)
 
 

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -628,7 +628,9 @@ class VideoXBlock(TranscriptsMixin, StudioEditableXBlockMixin, XBlock):
 
         # TODO consider: move auth fields validation and kwargs population to specific backends
         # Handles a case where no token was provided by a user
-        if self.token == self.fields['token'].default and str(self.player_name) != 'youtube-player':  # pylint: disable=unsubscriptable-object
+        is_default_token = self.token == self.fields['token'].default  # pylint: disable=unsubscriptable-object
+        is_youtube_player = str(self.player_name) != 'youtube-player'  # pylint: disable=unsubscriptable-object
+        if is_default_token and is_youtube_player:
             error_message = 'In order to authenticate to a video platform\'s API, please provide a Video API Token.'
             return {}, error_message
         if token:


### PR DESCRIPTION
```
./setup.py:47:56: E231 missing whitespace after ','
./video_xblock/video_xblock.py:474:61: E261 at least two spaces before inline comment
./video_xblock/video_xblock.py:475:57: E261 at least two spaces before inline comment
./video_xblock/backends/brightcove.py:239:17: E123 closing bracket does not match indentation of opening bracket's line
./video_xblock/tests/test_video_xblock.py:109:61: E261 at least two spaces before inline comment
./video_xblock/tests/test_video_xblock.py:111:27: E231 missing whitespace after ':'
./video_xblock/video_xblock.py:29:1: E731 do not assign a lambda expression, use a def
./video_xblock/tests/test_video_xblock.py:19:1: E731 do not assign a lambda expression, use a def
```

@z4y4ts @OPersian please review