### PR TITLE
Reduce target python versions to latest and the one used by Eucalyptus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - "2.7"
   - "2.7.10"
-  - "2.7.12"
   - "2.7.13"
 
 cache: pip


### PR DESCRIPTION
To speed up TravisCI build time.