### PR TITLE
Tweak .travis.yml for faster build times and bump XBlock dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: python
+sudo: false
 python:
   - "2.7.10"
   - "2.7.13"
+
+addons:
+  apt:
+    packages:
+    - python-lxml
 
 cache:
   pip: true
@@ -13,8 +19,8 @@ before_install:
   # Install latest stable NodeJS version. Required for eslint.
   - nvm install stable
   # Install binary package for lxml to speed up build
-  - sudo apt-get -qq update
-  - sudo apt-get install -y python-lxml
+  # - sudo apt-get -qq update
+  # - sudo apt-get install -y
 
 before_script:
   - make deps-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 addons:
   apt:
     packages:
+    # Install binary package for lxml to speed up build
     - python-lxml
 
 cache:
@@ -18,9 +19,6 @@ cache:
 before_install:
   # Install latest stable NodeJS version. Required for eslint.
   - nvm install stable
-  # Install binary package for lxml to speed up build
-  # - sudo apt-get -qq update
-  # - sudo apt-get install -y
 
 before_script:
   - make deps-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   pip: true
   directories:
     - node_modules # NPM packages
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/src/xmodule
 
 before_install:
   # Install latest stable NodeJS version. Required for eslint.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
   pip: true
   directories:
     - node_modules # NPM packages
-    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/src/xmodule
 
 before_install:
   # Install latest stable NodeJS version. Required for eslint.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Xblock==0.4.14
+XBlock==0.4.14
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 pycaption<1.0 # The latest Python 2.7 compatible version
 requests==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
+Xblock==0.4.14
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 pycaption<1.0 # The latest Python 2.7 compatible version
 requests==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 XBlock==0.4.14
+# At the moment of writing PyPI hosts outdated version of xblock-utils, hence git
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 pycaption<1.0 # The latest Python 2.7 compatible version
 requests==2.9.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 # Auto-transcripts upload is dependent on xmodule.contentstore
-git+https://github.com/edx/edx-platform.git@open-release/eucalyptus.3#egg=xmodule==0.1.1&subdirectory=common/lib/xmodule/
+-e git+https://github.com/edx/edx-platform.git@open-release/eucalyptus.3#egg=xmodule==0.1.1&subdirectory=common/lib/xmodule/
 PyContracts==1.7.1   # xmodule dependency
 sortedcontainers==0.9.2  # xmodule dependency
 Pillow==3.1.1  # xmodule dependency

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 # Auto-transcripts upload is dependent on xmodule.contentstore
--e git+https://github.com/edx/edx-platform.git@open-release/eucalyptus.3#egg=xmodule==0.1.1&subdirectory=common/lib/xmodule/
+git+https://github.com/edx/edx-platform.git@open-release/eucalyptus.3#egg=xmodule==0.1.1&subdirectory=common/lib/xmodule/
 PyContracts==1.7.1   # xmodule dependency
 sortedcontainers==0.9.2  # xmodule dependency
 Pillow==3.1.1  # xmodule dependency


### PR DESCRIPTION
- Bump Xblock dep to 0.4.14 and install it from PyPI rather than git
- Switch to container-based Travis build
- Install python-lxml using Travis' apt addon
