### PR TITLE
Feature/backend specific fields

### DIFF
--- a/video_xblock/backends/base.py
+++ b/video_xblock/backends/base.py
@@ -7,6 +7,7 @@ Base Video player plugin.
 """
 
 import abc
+from itertools import chain
 import json
 import re
 
@@ -104,6 +105,16 @@ class BaseVideoPlayer(Plugin):
         """
         return []
 
+    @property
+    def fields_help(self):
+        """
+        Declare backend specific fields' help text.
+
+        Example:
+            {'token': 'Get your token at https://example.com/get-token'}
+        """
+        return {}
+
     def get_frag(self, **context):
         """
         Return a Fragment required to render video player on the client side.
@@ -181,10 +192,9 @@ class BaseVideoPlayer(Plugin):
         E.g. 'account_id' should be displayed for Brightcove only.
 
         Returns:
-            client_token_help_message (str): Help message with results of client token generation.
             editable_fields (tuple): All the editable fields to be displayed in studio editor modal.
         """
-        return '', ()
+        return ()
 
     def get_player_html(self, **context):
         """

--- a/video_xblock/backends/base.py
+++ b/video_xblock/backends/base.py
@@ -106,6 +106,33 @@ class BaseVideoPlayer(Plugin):
         return []
 
     @property
+    def editable_fields(self):
+        """
+        Tuple of all editable VideoXBlock fields to display in studio edit window.
+
+        Defaults to contatenation of `basic_fields` and `advanced_fields`.
+        """
+        return tuple(chain(self.basic_fields, self.advanced_fields))
+
+    @property
+    def basic_fields(self):
+        """
+        Tuple of VideoXBlock fields to display in Basic tab of edit modal window.
+
+        Subclasses can extend or redefine list if needed. Defaults to a tuple defined by VideoXBlock.
+        """
+        return self.xblock.basic_fields
+
+    @property
+    def advanced_fields(self):
+        """
+        Tuple of VideoXBlock fields to display in Advanced tab of edit modal window.
+
+        Subclasses can extend or redefine list if needed. Defaults to a tuple defined by VideoXBlock.
+        """
+        return self.xblock.advanced_fields
+
+    @property
     def fields_help(self):
         """
         Declare backend specific fields' help text.
@@ -182,19 +209,6 @@ class BaseVideoPlayer(Plugin):
         E.g. https://example.wistia.com/medias/12345abcde -> 12345abcde
         """
         return ''
-
-    @staticmethod
-    @abc.abstractmethod
-    def customize_xblock_fields_display(editable_fields):  # pylint: disable=unused-argument
-        """
-        Customise display of studio editor fields per video platform.
-
-        E.g. 'account_id' should be displayed for Brightcove only.
-
-        Returns:
-            editable_fields (tuple): All the editable fields to be displayed in studio editor modal.
-        """
-        return ()
 
     def get_player_html(self, **context):
         """

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -328,7 +328,14 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
     # Stores default transcripts fetched from the captions API
     default_transcripts = []
 
-    basic_fields = BaseVideoPlayer.basic_fields + ('account_id',)
+    @property
+    def basic_fields(self):
+        """
+        Tuple of VideoXBlock fields to display in Basic tab of edit modal window.
+
+        Brightcove videos require Brightcove Account id.
+        """
+        return super(BrightcovePlayer, self).basic_fields + ('account_id',)
 
     advanced_fields = (
         'player_id', 'start_time', 'end_time', 'handout', 'transcripts',

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -328,6 +328,15 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
     # Stores default transcripts fetched from the captions API
     default_transcripts = []
 
+    @property
+    def basic_fields(self):
+        return super(BrightcovePlayer, self).basic_fields + ('account_id',)
+
+    advanced_fields = (
+        'player_id', 'start_time', 'end_time', 'handout', 'transcripts',
+        'download_transcript_allowed', 'token', 'default_transcripts'
+    )
+
     fields_help = {
         'token': 'You can generate a BC token following the guide of '
                  '<a href="https://docs.brightcove.com/en/video-cloud/oauth-api/guides/get-client-credentials.html" '
@@ -450,13 +459,6 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
             self.xblock.metadata.get('client_secret')
         )
         return {'canShow': can_show}
-
-    @staticmethod
-    def customize_xblock_fields_display(editable_fields):
-        """
-        Customise display of Brightcove's studio editor fields.
-        """
-        return editable_fields
 
     def authenticate_api(self, **kwargs):
         """

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -328,9 +328,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
     # Stores default transcripts fetched from the captions API
     default_transcripts = []
 
-    @property
-    def basic_fields(self):
-        return super(BrightcovePlayer, self).basic_fields + ('account_id',)
+    basic_fields = BaseVideoPlayer.basic_fields + ('account_id',)
 
     advanced_fields = (
         'player_id', 'start_time', 'end_time', 'handout', 'transcripts',

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -328,6 +328,13 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
     # Stores default transcripts fetched from the captions API
     default_transcripts = []
 
+    fields_help = {
+        'token': 'You can generate a BC token following the guide of '
+                 '<a href="https://docs.brightcove.com/en/video-cloud/oauth-api/guides/get-client-credentials.html" '
+                 'target="_blank">Brightcove</a>. Please ensure appropriate operations scope has been set '
+                 'on the video platform, and a BC token is valid.'
+    }
+
     def __init__(self, xblock):
         """
         Initialize Brightcove player class object.
@@ -449,11 +456,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         """
         Customise display of Brightcove's studio editor fields.
         """
-        message = 'You can generate a BC token following the guide of ' \
-                  '<a href="https://docs.brightcove.com/en/video-cloud/oauth-api/guides/get-client-credentials.html" ' \
-                  'target="_blank">Brightcove</a>. Please ensure appropriate operations scope has been set ' \
-                  'on the video platform, and a BC token is valid.'
-        return message, editable_fields
+        return editable_fields
 
     def authenticate_api(self, **kwargs):
         """

--- a/video_xblock/backends/dummy.py
+++ b/video_xblock/backends/dummy.py
@@ -15,6 +15,7 @@ class DummyPlayer(BaseVideoPlayer):
 
     url_re = re.compile(r'')
     metadata_fields = []
+    advanced_fields = ()
 
     def get_frag(self, **context):  # pylint: disable=unused-argument
         """
@@ -49,13 +50,6 @@ class DummyPlayer(BaseVideoPlayer):
             language_code (str): Language code of a default transcript to be downloaded.
         """
         return u''
-
-    @staticmethod
-    def customize_xblock_fields_display(editable_fields):
-        """
-        Customise display of studio editor fields per video platform.
-        """
-        return editable_fields
 
     def authenticate_api(self, **kwargs):  # pylint: disable=unused-argument
         """

--- a/video_xblock/backends/dummy.py
+++ b/video_xblock/backends/dummy.py
@@ -55,7 +55,7 @@ class DummyPlayer(BaseVideoPlayer):
         """
         Customise display of studio editor fields per video platform.
         """
-        return '', editable_fields
+        return editable_fields
 
     def authenticate_api(self, **kwargs):  # pylint: disable=unused-argument
         """

--- a/video_xblock/backends/vimeo.py
+++ b/video_xblock/backends/vimeo.py
@@ -18,6 +18,10 @@ class VimeoPlayer(BaseVideoPlayer):
 
     metadata_fields = []
 
+    fields_help = {
+        'token': 'This field is to be disabled.'
+    }
+
     # Vimeo API for requesting transcripts.
     captions_api = {}
 
@@ -96,10 +100,9 @@ class VimeoPlayer(BaseVideoPlayer):
         """
         Customise display of studio editor fields per a video platform.
         """
-        message = 'This field is to be disabled.'
         editable_fields = list(editable_fields)
         editable_fields.remove('account_id')
         editable_fields.remove('player_id')
         editable_fields.remove('token')
         customised_editable_fields = tuple(editable_fields)
-        return message, customised_editable_fields
+        return customised_editable_fields

--- a/video_xblock/backends/vimeo.py
+++ b/video_xblock/backends/vimeo.py
@@ -94,15 +94,3 @@ class VimeoPlayer(BaseVideoPlayer):
         Download default transcript in WebVVT format.
         """
         return u''
-
-    @staticmethod
-    def customize_xblock_fields_display(editable_fields):
-        """
-        Customise display of studio editor fields per a video platform.
-        """
-        editable_fields = list(editable_fields)
-        editable_fields.remove('account_id')
-        editable_fields.remove('player_id')
-        editable_fields.remove('token')
-        customised_editable_fields = tuple(editable_fields)
-        return customised_editable_fields

--- a/video_xblock/backends/vimeo.py
+++ b/video_xblock/backends/vimeo.py
@@ -18,10 +18,6 @@ class VimeoPlayer(BaseVideoPlayer):
 
     metadata_fields = []
 
-    fields_help = {
-        'token': 'This field is to be disabled.'
-    }
-
     # Vimeo API for requesting transcripts.
     captions_api = {}
 

--- a/video_xblock/backends/wistia.py
+++ b/video_xblock/backends/wistia.py
@@ -48,6 +48,12 @@ class WistiaPlayer(BaseVideoPlayer):
     # Stores default transcripts fetched from the captions API
     default_transcripts = []
 
+    fields_help = {
+        'token': 'You can get a master token following the guide of '
+                 '<a href="https://wistia.com/doc/data-api" target="_blank">Wistia</a>. '
+                 'Please ensure appropriate operations scope has been set on the video platform.'
+    }
+
     def media_id(self, href):
         """
         Extract Platform's media id from the video url.
@@ -107,14 +113,11 @@ class WistiaPlayer(BaseVideoPlayer):
         """
         Customize display of studio editor fields per a video platform.
         """
-        message = 'You can get a master token following the guide of ' \
-                  '<a href="https://wistia.com/doc/data-api" target="_blank">Wistia</a>. ' \
-                  'Please ensure appropriate operations scope has been set on the video platform.'
         editable_fields = list(editable_fields)
         editable_fields.remove('account_id')
         editable_fields.remove('player_id')
         customised_editable_fields = tuple(editable_fields)
-        return message, customised_editable_fields
+        return customised_editable_fields
 
     def authenticate_api(self, **kwargs):
         """

--- a/video_xblock/backends/wistia.py
+++ b/video_xblock/backends/wistia.py
@@ -24,6 +24,12 @@ class WistiaPlayer(BaseVideoPlayer):
     url_re = re.compile(
         r'https?:\/\/(.+)?(wistia.com|wi.st)\/(medias|embed)\/(?P<media_id>.*)'
     )
+
+    advanced_fields = (
+        'start_time', 'end_time', 'handout', 'transcripts',
+        'download_transcript_allowed', 'token', 'default_transcripts'
+    )
+
     # Token field is stored in metadata only if authentication was successful
     metadata_fields = ['token', ]
 
@@ -107,17 +113,6 @@ class WistiaPlayer(BaseVideoPlayer):
         frag.add_javascript(self.render_resource('static/js/player-context-menu.js', **context))
 
         return frag
-
-    @staticmethod
-    def customize_xblock_fields_display(editable_fields):
-        """
-        Customize display of studio editor fields per a video platform.
-        """
-        editable_fields = list(editable_fields)
-        editable_fields.remove('account_id')
-        editable_fields.remove('player_id')
-        customised_editable_fields = tuple(editable_fields)
-        return customised_editable_fields
 
     def authenticate_api(self, **kwargs):
         """

--- a/video_xblock/backends/youtube.py
+++ b/video_xblock/backends/youtube.py
@@ -101,20 +101,6 @@ class YoutubePlayer(BaseVideoPlayer):
 
         return frag
 
-    @staticmethod
-    def customize_xblock_fields_display(editable_fields):
-        """
-        Customise display of studio editor fields per a video platform.
-
-        Authentication to API is not required by Youtube API.
-        """
-        editable_fields = list(editable_fields)
-        editable_fields.remove('account_id')
-        editable_fields.remove('player_id')
-        editable_fields.remove('token')
-        customised_editable_fields = tuple(editable_fields)
-        return customised_editable_fields
-
     def authenticate_api(self, **kwargs):
         """
         Current Youtube captions API doesn't require authentication, but this may change.

--- a/video_xblock/backends/youtube.py
+++ b/video_xblock/backends/youtube.py
@@ -42,6 +42,10 @@ class YoutubePlayer(BaseVideoPlayer):
         }
     }
 
+    fields_help = {
+        'token': 'This field is to be disabled.'
+    }
+
     # Stores default transcripts fetched from the Youtube captions API
     default_transcripts = []
 
@@ -104,13 +108,12 @@ class YoutubePlayer(BaseVideoPlayer):
 
         Authentication to API is not required by Youtube API.
         """
-        message = 'This field is to be disabled.'
         editable_fields = list(editable_fields)
         editable_fields.remove('account_id')
         editable_fields.remove('player_id')
         editable_fields.remove('token')
         customised_editable_fields = tuple(editable_fields)
-        return message, customised_editable_fields
+        return customised_editable_fields
 
     def authenticate_api(self, **kwargs):
         """

--- a/video_xblock/backends/youtube.py
+++ b/video_xblock/backends/youtube.py
@@ -42,10 +42,6 @@ class YoutubePlayer(BaseVideoPlayer):
         }
     }
 
-    fields_help = {
-        'token': 'This field is to be disabled.'
-    }
-
     # Stores default transcripts fetched from the Youtube captions API
     default_transcripts = []
 

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -321,6 +321,13 @@ class VideoXBlock(TranscriptsMixin, StudioEditableXBlockMixin, XBlock):
         self.captions_enabled = state.get('captions_enabled', self.captions_enabled)
         self.captions_language = state.get('captions_language', self.captions_language)
 
+    @property
+    def editable_fields(self):
+        """
+        Return list of xblock's editable fields used by StudioEditableXBlockMixin.clean_studio_edits().
+        """
+        return self.get_player().editable_fields
+
     def validate_field_data(self, validation, data):
         """
         Validate data submitted via xblock edit pop-up.

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -251,11 +251,15 @@ class VideoXBlock(TranscriptsMixin, StudioEditableXBlockMixin, XBlock):
         help="Captions are enabled or not"
     )
 
-    editable_fields = (
-        'display_name', 'href', 'start_time', 'end_time', 'account_id',
-        'player_id', 'handout', 'transcripts', 'download_transcript_allowed',
-        'default_transcripts', 'token'
+    basic_fields = (
+        'display_name', 'href'
     )
+
+    advanced_fields = (
+        'start_time', 'end_time', 'handout', 'transcripts',
+        'download_transcript_allowed', 'default_transcripts'
+    )
+
     player_state_fields = (
         'current_time', 'muted', 'playback_rate', 'volume',
         'transcripts_enabled', 'captions_enabled', 'captions_language'
@@ -429,12 +433,8 @@ class VideoXBlock(TranscriptsMixin, StudioEditableXBlockMixin, XBlock):
             'transcripts_autoupload_message': transcripts_autoupload_message
         }
 
-        # Customize display of the particular xblock fields per each video platform.
-        self.editable_fields = \
-            player.customize_xblock_fields_display(self.editable_fields)  # pylint: disable=unsubscriptable-object
-
         # Build a list of all the fields that can be edited:
-        for field_name in self.editable_fields:
+        for field_name in self.get_player().editable_fields:
             field = self.fields[field_name]  # pylint: disable=unsubscriptable-object
             assert field.scope in (Scope.content, Scope.settings), (
                 "Only Scope.content or Scope.settings fields can be used with "
@@ -555,6 +555,12 @@ class VideoXBlock(TranscriptsMixin, StudioEditableXBlockMixin, XBlock):
         return player(self)
 
     def _get_field_help(self, field_name, field):
+        """
+        Get help text for field.
+
+        First try to load override from video backend, then check field definition
+        and lastly fall back to empty string.
+        """
         backend_fields_help = self.get_player().fields_help
         if field_name in backend_fields_help:
             return backend_fields_help[field_name]


### PR DESCRIPTION
On the XBlock edit window, show only those fields which make sense for a video.

Current solution requires Save & reopen window after video URL change.

No-reopen solution will be submitted in separate pull-request.