### PR TITLE
Remove duplicate message status and don’t hide previous message

### DIFF
--- a/video_xblock/static/html/studio-edit-default-transcripts.html
+++ b/video_xblock/static/html/studio-edit-default-transcripts.html
@@ -32,10 +32,6 @@
           <div class="api-response remove-default-transcript {{ default_transcript.lang }} status"></div>
         {% endfor %}
     {% endif %}
-    {% for initial_default_transcript in initial_default_transcripts %}
-      <!-- Success message of available transcript upload is to be displayed. -->
-      <div class="api-response upload-default-transcript {{ initial_default_transcript.lang }} status"></div>
-    {% endfor %}
     <!-- Hidden block (enabled sub) -->
     <div class="enabled-default-transcripts-section is-hidden">
       <div class="default-transcripts-label" value=""></div>

--- a/video_xblock/static/js/studio-edit-utils.js
+++ b/video_xblock/static/js/studio-edit-utils.js
@@ -27,15 +27,16 @@ function fillValues(fields) {
 
 /**
  * Display message with results of a performed action (e.g. a transcript manual or automatic upload).
- * @param {String}         message Status message for user to be displayed.
- * @param {String}         type    Message type: 'success' or 'error'.
  * @param {jQuery Element} $el     Container element where message should be displayed.
+ * @param {String}         type    Message type: 'success' or 'error'.
+ * @param {String}         message Status message for user to be displayed.
  */
 function showStatus($el, type, message) {
     'use strict';
+    // TODO: Convert into class and ensure previously set timeouts are cleared
+    //       before setting new timeout
+
     var msgShowTime = 5000; // 5 seconds
-    // Only one success message is to be displayed at once
-    $('.api-response').empty();
 
     $el.removeClass('status-error status-success is-hidden').addClass('status-' + type)
        .text(message);

--- a/video_xblock/static/js/studio-edit-utils.js
+++ b/video_xblock/static/js/studio-edit-utils.js
@@ -27,9 +27,9 @@ function fillValues(fields) {
 
 /**
  * Display message with results of a performed action (e.g. a transcript manual or automatic upload).
- * @param {jQuery Element} $el     Container element where message should be displayed.
- * @param {String}         type    Message type: 'success' or 'error'.
- * @param {String}         message Status message for user to be displayed.
+ * @param {jQuery Elements} $el     Container elements where message should be displayed.
+ * @param {String}          type    Message type: 'success' or 'error'.
+ * @param {String}          message Status message for user to be displayed.
  */
 function showStatus($el, type, message) {
     'use strict';


### PR DESCRIPTION
Conversion to a class is going to be a part of refactoring.
Apparently, there's no way to get query selector from a jQuery element after they've returned.