### PR TITLE
Hide explicit 3PlayMedia switch

### DIFF
--- a/video_xblock/static/html/studio-edit-transcripts-accordion.html
+++ b/video_xblock/static/html/studio-edit-transcripts-accordion.html
@@ -26,7 +26,7 @@
   <div class="accordion-panel {% if transcripts_type == '3PM' %}active{% endif %}" id="accordion-panel-3pm">
     {% for field in three_pm_fields %}
       <li
-        class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %}"
+        class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %} {% ifequal field.type 'boolean' %}is-hidden{% endifequal %}"
         data-field-name="{{field.name}}"
         data-default="{% if field.type == 'boolean' %}{{ field.default|yesno:'1,0' }}{% else %}{{ field.default|default_if_none:"" }}{% endif %}"
         data-cast="{{field.type}}"


### PR DESCRIPTION
Transcripts mode (e.g. 3PlayMedia-direct-streaming  vs  manual+default) now handled by accordion in studio view.