### PR TITLE
Fix default&manual transcripts accordion section

### DIFF
--- a/video_xblock/static/html/studio-edit-transcripts.html
+++ b/video_xblock/static/html/studio-edit-transcripts.html
@@ -2,7 +2,7 @@
 
 <div class="wrapper-uploader-actions xblock-edit-settings wrapper-translations-settings">
   <ol class="list-settings language-transcript-selector">
-    {% for transcript in transcripts %}
+    {% for transcript in enabled_managed_transcripts %}
     <li class="list-settings-item">
       <select name="language" class="lang-select">
         <option></option>

--- a/video_xblock/tests/unit/test_backends.py
+++ b/video_xblock/tests/unit/test_backends.py
@@ -170,6 +170,9 @@ class TestCustomBackends(VideoXBlockTestBase):
     @data(*zip(backends, expected_trans_fields, expected_3pm_fields))
     @unpack
     def test_transcripts_fields(self, backend, expected_trans_fields, expected_3pm_fields):
+        """
+        Test xBlock's transcript fields list is correct.
+        """
         player = self.player[backend](self.xblock)
         self.assertListEqual(player.trans_fields, expected_trans_fields)
         self.assertListEqual(player.three_pm_fields, expected_3pm_fields)
@@ -359,6 +362,9 @@ class TestCustomBackends(VideoXBlockTestBase):
     @data(*zip(backends, download_video_url_delegates))
     @unpack
     def test_download_video_url_delegates_to_proper_xblock_attribute(self, backend, patch_target):
+        """
+        Test video downloading URL delegates to proper xBlock's attribute.
+        """
         # Arrange
         delegate_mock = PropertyMock()
         setattr(self.xblock, patch_target, delegate_mock)
@@ -462,7 +468,6 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         """
         Test Vimeo's default transcripts fetching (positive scenario).
         """
-
         # Arrange
         test_json_data = {"data": [{"test_key": "test_value"}]}
         success_message = _('Default transcripts successfully fetched from a video platform.')
@@ -487,7 +492,6 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         """
         Test Vimeo's default transcripts fetching without provided API token.
         """
-
         # Arrange
         failure_message = _('No API credentials provided.')
 
@@ -505,7 +509,6 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         """
         Test Vimeo's default transcripts fetching with GET request failure.
         """
-
         # Arrange
         failure_message = _('No timed transcript may be fetched from a video platform.<br>')
 
@@ -524,7 +527,6 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         """
         Test Vimeo's default transcripts fetching with no data returned.
         """
-
         # Arrange
         test_json_data = []
         success_message = _('There are no default transcripts for the video on the video platform.')
@@ -544,7 +546,6 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         """
         Test Vimeo's default transcripts fetching with data parsing failure.
         """
-
         # Arrange
         test_json_data = {"data": [{"test_key": "test_value"}]}
         failure_message = "test_message"
@@ -568,7 +569,6 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         """
         Test Vimeo's default transcripts downloading.
         """
-
         # Arrange
         test_file_data = u"test_file_data"
         requests_get_mock.return_value = Mock(content=test_file_data)
@@ -640,8 +640,10 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         test_message = _('No timed transcript may be fetched from a video platform.\nError details: test_exc_message')
         test_url = 'https://api.wistia.com/v1/medias/test_video_id/captions.json?api_password=test_token'
         requests_get_mock.side_effect = requests.RequestException("test_exc_message")
+
         # Act
         transcripts, message = self.wistia_player.get_default_transcripts(**kwargs)
+
         # Assert
         requests_get_mock.assert_called_once_with(test_url)
         self.assertEqual(transcripts, [])
@@ -660,8 +662,10 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         test_message = "Wistia video test_wrong_video_id doesn't exist."
         test_url = 'https://api.wistia.com/v1/medias/test_wrong_video_id/captions.json?api_password=test_token'
         requests_get_mock.return_value = ResponseStub(status_code=404, body=[])
+
         # Act
         transcripts, message = self.wistia_player.get_default_transcripts(**kwargs)
+
         # Assert
         requests_get_mock.assert_called_once_with(test_url)
         self.assertEqual(transcripts, [])
@@ -680,8 +684,10 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         test_message = "Invalid request."
         test_url = 'https://api.wistia.com/v1/medias/test_video_id/captions.json?api_password=test_token'
         requests_get_mock.return_value = ResponseStub(status_code=400, ok=False, body=[])
+
         # Act
         transcripts, message = self.wistia_player.get_default_transcripts(**kwargs)
+
         # Assert
         requests_get_mock.assert_called_once_with(test_url)
         self.assertEqual(transcripts, [])
@@ -701,8 +707,10 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         test_url = 'https://api.wistia.com/v1/medias/test_video_id/captions.json?api_password=test_token'
         requests_get_mock.return_value = response_mock = ResponseStub(status_code=200)
         response_mock.json = Mock(side_effect=ValueError())
+
         # Act
         transcripts, message = self.wistia_player.get_default_transcripts(**kwargs)
+
         # Assert
         requests_get_mock.assert_called_once_with(test_url)
         self.assertEqual(transcripts, [])
@@ -751,11 +759,10 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         """
         Test Wistia's default transcripts downloading (positive scenario).
         """
-
         # Arrange
         test_api_data = {'text': 'test_content'}
-        test_url = u"test_url"
-        test_language_code = u"test_language_code"
+        test_url = "test_url"
+        test_language_code = "test_language_code"
 
         requests_get_mock.return_value = ResponseStub(status_code=200, body=test_api_data)
 
@@ -771,7 +778,6 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         """
         Test Wistia's default transcripts downloading (request failure).
         """
-
         # Arrange
         test_url = u"test_url"
         test_language_code = u"test_language_code"
@@ -790,7 +796,6 @@ class WistiaPlayerTest(VideoXBlockTestBase):
         """
         Test Wistia's default transcripts downloading (request parsing failure).
         """
-
         # Arrange
         test_url = u"test_url"
         test_language_code = u"test_language_code"

--- a/video_xblock/tests/unit/test_constants.py
+++ b/video_xblock/tests/unit/test_constants.py
@@ -15,7 +15,9 @@ class ConstantsTest(unittest.TestCase):
     """
 
     def test_three_play_media_language_data_constant_creation(self):
-        """Test 3PlayMedia available transcript language_info object creation"""
+        """
+        Test 3PlayMedia available transcript language_info object creation.
+        """
         self.assertRaises(ValueError, TPMApiLanguage, 'a')
         self.assertRaises(ValueError, TPMApiLanguage, 999)
 
@@ -34,7 +36,9 @@ class ConstantsTest(unittest.TestCase):
         }
     })
     def test_three_play_media_language_data_constant_structure(self, test_data):
-        """Test 3PlayMedia available transcript language_info object creation"""
+        """
+        Test 3PlayMedia available transcript language_info object creation.
+        """
         for lang_id, lang_info in test_data.items():
             self.assertEqual(TPMApiLanguage(lang_id).ietf_code, lang_info["ietf_code"])
             self.assertEqual(TPMApiLanguage(lang_id).iso_639_1_code, lang_info["iso_639_1_code"])

--- a/video_xblock/tests/unit/test_mixins.py
+++ b/video_xblock/tests/unit/test_mixins.py
@@ -25,6 +25,9 @@ class ContentStoreMixinTest(VideoXBlockTestBase):
 
     @patch('video_xblock.mixins.import_from')
     def test_contentstore_no_service(self, import_mock):
+        """
+        Test content store is imported.
+        """
         import_mock.return_value = 'contentstore_test'
 
         self.assertEqual(self.xblock.contentstore, 'contentstore_test')
@@ -32,12 +35,18 @@ class ContentStoreMixinTest(VideoXBlockTestBase):
 
     @patch('video_xblock.mixins.import_from')
     def test_static_content_no_service(self, import_mock):
+        """
+        Test proper content store is used.
+        """
         import_mock.return_value = 'StaticContent_test'
 
         self.assertEqual(self.xblock.static_content, 'StaticContent_test')
         import_mock.assert_called_once_with('xmodule.contentstore.content', 'StaticContent')
 
     def test_contentstore(self):
+        """
+        Test xBlock's contentstore property works properly.
+        """
         with patch.object(self.xblock, 'runtime') as runtime_mock:
             service_mock = runtime_mock.service
             type(service_mock.return_value).contentstore = cs_mock = PropertyMock(
@@ -49,6 +58,9 @@ class ContentStoreMixinTest(VideoXBlockTestBase):
             cs_mock.assert_called_once()
 
     def test_static_content(self):
+        """
+        Test xBlock's StaticContent property works properly.
+        """
         with patch.object(self.xblock, 'runtime') as runtime_mock:
             service_mock = runtime_mock.service
             type(service_mock.return_value).StaticContent = sc_mock = PropertyMock(
@@ -64,18 +76,33 @@ class LocationMixinTests(VideoXBlockTestBase):
     """Test LocationMixin"""
 
     def test_xblock_doesnt_have_location_by_default(self):
+        """
+        Test xBlock doesn't have location by default.
+        """
         self.assertFalse(hasattr(self.xblock, 'location'))
 
     def test_fallback_block_id(self):
+        """
+        Test xBlock's has default `block_id` value.
+        """
         self.assertEqual(self.xblock.block_id, 'block_id')
 
     def test_fallback_course_key(self):
+        """
+        Test xBlock's has default `course_key` value.
+        """
         self.assertEqual(self.xblock.course_key, 'course_key')
 
     def test_fallback_usage_id(self):
+        """
+        Test xBlock's has default `usage_id` value.
+        """
         self.assertEqual(self.xblock.usage_id, 'usage_id')
 
     def test_block_id(self):
+        """
+        Test xBlock's `block_id` property works properly.
+        """
         self.xblock.location = Mock()
         type(self.xblock.location).block_id = block_mock = PropertyMock(
             return_value='test_block_id'
@@ -85,6 +112,9 @@ class LocationMixinTests(VideoXBlockTestBase):
         block_mock.assert_called_once()
 
     def test_course_key(self):
+        """
+        Test xBlock's `course_key` property works properly.
+        """
         self.xblock.location = Mock()
 
         type(self.xblock.location).course_key = course_key_mock = PropertyMock(
@@ -95,6 +125,9 @@ class LocationMixinTests(VideoXBlockTestBase):
         course_key_mock.assert_called_once()
 
     def test_usage_id(self):
+        """
+        Test xBlock's `usage_id` property works properly.
+        """
         self.xblock.location = Mock()
         self.xblock.location.to_deprecated_string = str_mock = Mock(
             return_value='test_str'
@@ -105,9 +138,14 @@ class LocationMixinTests(VideoXBlockTestBase):
 
 
 class PlaybackStateMixinTests(VideoXBlockTestBase):
-    """Test PlaybackStateMixin"""
+    """
+    Test PlaybackStateMixin.
+    """
 
     def test_fallback_course_default_language(self):
+        """
+        Test xBlock's `course_default_language` property falls back to DEFAULT_LANG.
+        """
         with patch.object(self.xblock, 'runtime') as runtime_mock:
             runtime_mock.service = service_mock = Mock(side_effect=NoSuchServiceError)
 
@@ -115,6 +153,9 @@ class PlaybackStateMixinTests(VideoXBlockTestBase):
             service_mock.assert_called_once()
 
     def test_course_default_language(self):
+        """
+        Test xBlock's `course_default_language` property works properly.
+        """
         with patch.object(self.xblock, 'runtime') as runtime_mock:
             service_mock = runtime_mock.service
             lang_mock = type(service_mock.return_value.get_course.return_value).language = PropertyMock(
@@ -189,7 +230,6 @@ class SettingsMixinTests(VideoXBlockTestBase):
     """
     Test SettingsMixin
     """
-
     @override_settings(
         XBLOCK_SETTINGS={
             'domain.com': {
@@ -203,6 +243,9 @@ class SettingsMixinTests(VideoXBlockTestBase):
         }
     )
     def test_settings_property_with_microsite_enabled(self):
+        """
+        Test settings property works with enabled microsites.
+        """
         # Arrange
         with patch.object(self.xblock, 'get_current_site_name') as get_current_site_name_mock:
             get_current_site_name_mock.return_value = 'foo.domain.com'
@@ -222,6 +265,9 @@ class SettingsMixinTests(VideoXBlockTestBase):
         }
     )
     def test_settings_property_with_microsite_disabled(self):
+        """
+        Test settings property works with enabled microsites.
+        """
         # Arrange
         with patch.object(self.xblock, 'get_current_site_name') as get_current_site_name_mock:
             get_current_site_name_mock.return_value = None  # SITE_NAME env variable isn't set
@@ -234,6 +280,9 @@ class SettingsMixinTests(VideoXBlockTestBase):
 
     @patch.object(VideoXBlock, 'settings', new_callable=PropertyMock)
     def test_populate_default_values(self, settings_mock):
+        """
+        Test xBlock fields' default values are populated properly.
+        """
         # Arrange
         settings_mock.return_value = {'foo': 'another bar', 'spam': 'eggs'}
         xblock_fields_dict = {'foo': 'bar'}
@@ -246,19 +295,25 @@ class SettingsMixinTests(VideoXBlockTestBase):
 
     @override_settings(
         # Arrange
-        SITE_NAME='foo.domain.name'
+        SITE_NAME='foo.example.com'
     )
     def test_get_current_site_name_success(self):
+        """
+        Test current site name may be fetched.
+        """
         # Act
         prefix = self.xblock.get_current_site_name()
         # Assert
-        self.assertEqual(prefix, 'foo.domain.name')
+        self.assertEqual(prefix, 'foo.example.com')
 
     @override_settings(
         # Arrange
         SITE_NAME=None
     )
     def test_get_current_site_name_failure(self):
+        """
+        Test current site name absence handling.
+        """
         # Act
         prefix = self.xblock.get_current_site_name()
         # Assert
@@ -266,11 +321,16 @@ class SettingsMixinTests(VideoXBlockTestBase):
 
 
 class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inherits-tests
-    """Test TranscriptsMixin"""
+    """
+    Test TranscriptsMixin
+    """
 
     @patch('video_xblock.mixins.WebVTTWriter.write')
     @patch('video_xblock.mixins.detect_format')
     def test_convert_caps_to_vtt(self, detect_format_mock, vtt_writer_mock):
+        """
+        Test caps to vtt convertation works properly.
+        """
         detect_format_mock.return_value.return_value.read = read_mock = Mock()
         read_mock.return_value = 'non vtt transcript'
         vtt_writer_mock.return_value = 'vtt transcript'
@@ -281,6 +341,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
     @patch('video_xblock.mixins.WebVTTWriter.write')
     @patch('video_xblock.mixins.detect_format')
     def test_convert_caps_to_vtt_fallback(self, detect_format_mock, vtt_writer_mock):
+        """
+        Test caps to vtt convertation falls back to empty unicode object.
+        """
         detect_format_mock.return_value = None
 
         self.assertEqual(self.xblock.convert_caps_to_vtt('test caps'), u'')
@@ -291,6 +354,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
     @patch.object(VideoXBlock, 'contentstore')
     @patch.object(VideoXBlock, 'course_key', new_callable=PropertyMock)
     def test_create_transcript_file(self, course_key, contentstore_mock, static_content_mock):
+        """
+        Test transcript file created properly.
+        """
         # Arrange
         trans_srt_stub = 'test srt transcript'
         reference_name_stub = 'test transcripts'
@@ -315,6 +381,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
     @patch.object(VideoXBlock, 'get_file_name_from_path')
     @patch('video_xblock.mixins.requests.get')
     def test_download_transcript_handler_response_object(self, get_mock, get_filename_mock):
+        """
+        Test transcripts downloading works properly.
+        """
         # Arrange
         get_filename_mock.return_value = 'transcript.vtt'
         get_mock.return_value.text = 'vtt transcripts'
@@ -337,6 +406,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
     @patch.object(VideoXBlock, 'captions_language', new_callable=PropertyMock)
     @patch.object(VideoXBlock, 'transcripts', new_callable=PropertyMock)
     def test_get_transcript_download_link(self, trans_mock, lang_mock):
+        """
+        Test transcript downloading link created properly.
+        """
         lang_mock.return_value = 'en'
         trans_mock.return_value = '[{"lang": "en", "url": "test_transcript.vtt"}]'
 
@@ -344,11 +416,17 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
 
     @patch.object(VideoXBlock, 'transcripts', new_callable=PropertyMock)
     def test_get_transcript_download_link_fallback(self, trans_mock):
+        """
+        Test transcript downloading link creation falls back to empty string.
+        """
         trans_mock.return_value = ''
 
         self.assertEqual(self.xblock.get_transcript_download_link(), '')
 
     def test_route_transcripts(self):
+        """
+        Test transcript rerouting works.
+        """
         # Arrange
         transcripts = [{"url": "test-trans.srt"}]
         with patch.object(self.xblock, 'runtime') as runtime_mock, \
@@ -371,6 +449,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
     @patch('video_xblock.mixins.requests', new_callable=MagicMock)
     @patch.object(VideoXBlock, 'convert_caps_to_vtt')
     def test_srt_to_vtt(self, convert_caps_to_vtt_mock, requests_mock):
+        """
+        Test xBlock's srt-to-vtt convertation works properly.
+        """
         # Arrange
         request_mock = MagicMock()
         convert_caps_to_vtt_mock.return_value = 'vtt transcripts'
@@ -386,6 +467,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         convert_caps_to_vtt_mock.assert_called_once_with(text_mock)
 
     def test_fetch_available_3pm_transcripts_with_errors(self):
+        """
+        Test available 3PlayMedia transcripts fetching (failure case).
+        """
         # Arrange:
         test_feedback = {'status': Status.error, 'message': 'test_message'}
         test_transcripts_list = []
@@ -393,15 +477,20 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
                 patch.object(self.xblock, 'threeplaymedia_file_id') as file_id_mock, \
                 patch.object(self.xblock, 'threeplaymedia_apikey') as apikey_mock:
             threepm_transcripts_mock.return_value = test_feedback, test_transcripts_list
+
             # Act:
             transcripts_gen = self.xblock.fetch_available_3pm_transcripts()
             transcripts = list(transcripts_gen)
+
             # Assert:
             self.assertEqual(transcripts, [])
             self.assertRaises(StopIteration, transcripts_gen.next)
             threepm_transcripts_mock.assert_called_once_with(file_id_mock, apikey_mock)
 
     def test_fetch_available_3pm_transcripts_success(self):
+        """
+        Test available 3PlayMedia transcripts fetching (success case).
+        """
         # Arrange:
         test_feedback = {'status': Status.success, 'message': 'test_message'}
         test_transcripts_list = [{'id': 'test_id', 'language_id': '2'}]
@@ -413,9 +502,11 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
                 patch.object(self.xblock, 'threeplaymedia_apikey') as apikey_mock:
             threepm_transcripts_mock.return_value = test_feedback, test_transcripts_list
             fetch_3pm_translation_mock.return_value = Transcript(*test_args)
+
             # Act:
             transcripts_gen = self.xblock.fetch_available_3pm_transcripts()
             transcripts = list(transcripts_gen)
+
             # Assert:
             self.assertIsInstance(transcripts[0], OrderedDict)
             self.assertSequenceEqual(test_args, transcripts[0].keys())
@@ -424,6 +515,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
 
     @patch('video_xblock.mixins.requests.get')
     def test_get_3pm_transcripts_list_success(self, requests_get_mock):
+        """
+        Test fetching of the list of available 3PlayMedia transcripts (success case).
+        """
         # Arrange:
         test_json = [{"test": "json_string"}]
         test_message = _("3PlayMedia transcripts fetched successfully.")
@@ -435,8 +529,10 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         file_id = 'test_file_id'
         api_key = 'test_api_key'
         test_api_url = 'https://static.3playmedia.com/files/test_file_id/transcripts?apikey=test_api_key'
+
         # Act:
         feedback, transcripts_list = self.xblock.get_3pm_transcripts_list(file_id, api_key)
+
         # Assert:
         self.assertTrue(requests_get_mock.ok)
         self.assertTrue(requests_get_mock.json.assert_called)
@@ -446,6 +542,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
 
     @patch('video_xblock.mixins.requests.get')
     def test_get_3pm_transcripts_list_api_failure(self, requests_get_mock):
+        """
+        Test fetching of the list of available 3PlayMedia transcripts (api failure case).
+        """
         # Arrange:
         test_message = _("3PlayMedia transcripts fetching API request has failed!")
         test_feedback = {'status': Status.error, 'message': test_message}
@@ -453,8 +552,10 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         file_id = 'test_file_id'
         api_key = 'test_api_key'
         test_api_url = 'https://static.3playmedia.com/files/test_file_id/transcripts?apikey=test_api_key'
+
         # Act:
         feedback, transcripts_list = self.xblock.get_3pm_transcripts_list(file_id, api_key)
+
         # Assert:
         self.assertEqual(transcripts_list, [])
         self.assertEqual(feedback, test_feedback)
@@ -463,6 +564,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
     @patch.object(VideoXBlock, 'get_player')
     @patch('video_xblock.mixins.requests.get')
     def test_fetch_single_3pm_translation_success(self, requests_get_mock, player_mock):
+        """
+        Test single 3PlayMedia transcript fetching (success case).
+        """
         # Arrange:
         test_lang_id = '1'
         test_transcript_text = 'test_transcript_text'
@@ -501,7 +605,32 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         # Assert:
         self.assertEqual(transcript, Transcript(*test_args))
 
+    @patch('video_xblock.mixins.requests.get')
+    def test_fetch_single_3pm_translation_failure(self, requests_get_mock):
+        """
+        Test single 3PlayMedia transcript fetching (failure case).
+        """
+        # Arrange:
+        test_lang_id = '1'
+        test_transcript_id = 'test_id'
+        file_id = 'test_file_id'
+        api_key = 'test_api_key'
+
+        test_transcript_data = {'id': test_transcript_id, 'language_id': test_lang_id}
+        requests_get_mock.side_effect = IOError()
+
+        self.xblock.threeplaymedia_file_id = file_id
+        self.xblock.threeplaymedia_apikey = api_key
+
+        # Act:
+        transcript = self.xblock.fetch_single_3pm_translation(test_transcript_data)
+        # Assert:
+        self.assertIsNone(transcript)
+
     def test_validate_three_play_media_config_initial_case(self):
+        """
+        Test 3PlayMedia configuration validation (initial case).
+        """
         # Arrange:
         success_message = _("Initialization")
         request_mock = arrange_request_mock(
@@ -518,6 +647,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         )
 
     def test_validate_three_play_media_config_without_streaming(self):
+        """
+        Test 3PlayMedia configuration validation (streaming disabled case).
+        """
         # Arrange:
         success_message = _('Success')
         request_mock = arrange_request_mock(
@@ -534,6 +666,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         )
 
     def test_validate_three_play_media_config_partially_configured(self):
+        """
+        Test 3PlayMedia configuration validation (improperly configured case).
+        """
         # Arrange:
         invalid_message = _('Check provided 3PlayMedia configuration')
         request_mock = arrange_request_mock(
@@ -551,6 +686,9 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
 
     @patch.object(VideoXBlock, 'get_3pm_transcripts_list')
     def test_validate_three_play_media_config_with_3pm_streaming(self, get_3pm_transcripts_list_mock):
+        """
+        Test 3PlayMedia configuration validation (streaming enabled case).
+        """
         # Arrange:
         success_message = _('Success')
         test_feedback = {'status': Status.success, 'message': success_message}
@@ -570,29 +708,11 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
         )
         get_3pm_transcripts_list_mock.assert_called_once_with("test_fileid", "test_apikey")  # Python string
 
-    @patch('video_xblock.mixins.requests.get')
-    def test_fetch_single_3pm_translation_failure(self, requests_get_mock):
-        # Arrange:
-        test_lang_id = '1'
-        test_transcript_id = 'test_id'
-        file_id = 'test_file_id'
-        api_key = 'test_api_key'
-
-        test_transcript_data = {'id': test_transcript_id, 'language_id': test_lang_id}
-        requests_get_mock.side_effect = IOError()
-
-        self.xblock.threeplaymedia_file_id = file_id
-        self.xblock.threeplaymedia_apikey = api_key
-
-        # Act:
-        transcript = self.xblock.fetch_single_3pm_translation(test_transcript_data)
-        # Assert:
-        self.assertIsNone(transcript)
-
 
 class WorkbenchMixinTest(VideoXBlockTestBase):
-    """Test WorkbenchMixin"""
-
+    """
+    Test WorkbenchMixin
+    """
     @patch.object(loader, 'load_scenarios_from_path')
     def test_workbench_scenarios(self, loader_mock):
         loader_mock.return_value = [('Scenario', '<xml/>')]

--- a/video_xblock/tests/unit/test_utils.py
+++ b/video_xblock/tests/unit/test_utils.py
@@ -33,6 +33,9 @@ class UtilsTest(unittest.TestCase):
 
     @patch('video_xblock.utils.import_module')
     def test_import_from(self, import_module_mock):
+        """
+        Test module importing function.
+        """
         import_module_mock.return_value = module_mock = Mock()
         type(module_mock).test_class = class_mock = PropertyMock(
             return_value='a_class'
@@ -43,6 +46,9 @@ class UtilsTest(unittest.TestCase):
         class_mock.assert_called_once_with()
 
     def test_create_reference_name(self):
+        """
+        Test file reference created in given format.
+        """
         # Arrange:
         lang_label = 'test_lang_label'
         video_id = 'test_video_id'
@@ -54,6 +60,9 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(reference, expected_ref)
 
     def test_normalize_transcripts_abnormal(self):
+        """
+        Test abnormal transcripts became normalized.
+        """
         # Arrange
         test_transcripts = [{'source': 'default'}, {}]
         expected_transcripts = [{'source': 'default'}, {'source': 'manual'}]
@@ -63,6 +72,9 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(normalized_transcripts, expected_transcripts)
 
     def test_normalize_transcripts_normal(self):
+        """
+        Test normal transcripts stay normal after normalizing.
+        """
         # Arrange
         test_transcripts = [{'source': 'default'}, {'source': 'some_else'}]
         expected_transcripts = [{'source': 'default'}, {'source': 'some_else'}]
@@ -72,6 +84,9 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(normalized_transcripts, expected_transcripts)
 
     def test_filter_transcripts_by_source_empty(self):
+        """
+        Test transcripts filtering can handle empty transcripts set.
+        """
         # Arrange
         test_transcripts = []
 
@@ -83,6 +98,9 @@ class UtilsTest(unittest.TestCase):
         self.assertListEqual(filtered_transcripts, test_transcripts)
 
     def test_filter_transcripts_by_source_by_default(self):
+        """
+        Test transcripts filtering works with default filtering configuration.
+        """
         # Arrange
         default_transcripts = [{'id': 'DT1', 'source': 'default'}, {'id': 'DT2', 'source': 'default'}]
         manual_transcripts = [{'id': 'MT1', 'source': 'manual'}, {'id': 'MT2', 'source': 'manual'}]
@@ -97,6 +115,9 @@ class UtilsTest(unittest.TestCase):
         self.assertListEqual(list(filtered_transcripts), default_transcripts)
 
     def test_filter_transcripts_by_source_exclude(self):
+        """
+        Test transcripts filtering `exclude` mode works.
+        """
         # Arrange
         default_transcripts = [{'id': 'DT1', 'source': 'default'}, {'id': 'DT2', 'source': 'default'}]
         manual_transcripts = [{'id': 'MT1', 'source': 'manual'}, {'id': 'MT2', 'source': 'manual'}]

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -71,6 +71,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
             self, brightcove_js_url_mock, player_state_mock, player_mock,
             route_transcripts_mock, render_resource_mock
     ):
+        """
+        Test `Brightcove` player renders properly.
+        """
         # Arrange
         request_mock, suffix_mock = Mock(), Mock()
         render_resource_mock.return_value = u'vtt transcripts'
@@ -113,6 +116,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
     @patch('video_xblock.video_xblock.resource_string')
     @patch.object(VideoXBlock, 'route_transcripts')
     def test_student_view(self, route_transcripts, resource_string_mock, render_resource_mock):
+        """
+        Test xBlock's student view builds proper Fragment.
+        """
         # Arrange
         unused_context_stub = object()
         render_resource_mock.return_value = u'<iframe/>'
@@ -157,6 +163,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
             authenticate_video_api_mock, _route_transcripts, render_template_mock,
             all_languages_mock
     ):
+        """
+        Test xBlock's student view gets proper context.
+        """
         # Arrange
         unused_context_stub = object()
         all_languages_mock.__iter__.return_value = [['en', 'English']]
@@ -229,6 +238,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
     def test_studio_view_uses_correct_resources(
             self, resource_string_mock, _route_transcripts, _render_template_mock
     ):
+        """
+        Test xBlock's student view creates properly configured Fragment instance.
+        """
         # Arrange
         unused_context_stub = object()
         self.xblock.runtime.handler_url = Mock()
@@ -257,11 +269,16 @@ class VideoXBlockTests(VideoXBlockTestBase):
 
     @patch('video_xblock.video_xblock.normalize_transcripts')
     def test_get_enabled_managed_transcripts_success(self, normalize_transcripts_mock):
+        """
+        Test xBlock gets enabled transcripts properly.
+        """
         # Arrange
         normalize_transcripts_mock.side_effect = lambda x: x
         self.xblock.transcripts = test_transcripts = '[{"transcript":"json"}]'
+
         # Act
         transcripts = self.xblock.get_enabled_transcripts()
+
         # Assert
         self.assertIsInstance(transcripts, list)
         self.assertEqual(transcripts, json.loads(test_transcripts))
@@ -269,6 +286,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
 
     @patch('video_xblock.video_xblock.normalize_transcripts')
     def test_get_enabled_managed_transcripts_failure(self, normalize_transcripts_mock):
+        """
+        Test xBlock gets enabled transcripts properly (dirty json).
+        """
         # Arrange
         normalize_transcripts_mock.side_effect = lambda x: x
         self.xblock.transcripts = '[{"transcript":bad_json}]'
@@ -287,6 +307,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
             fetch_3pm_transcripts_mock,
             get_managed_transcripts_mock
     ):
+        """
+        Test xBlock gets enabled transcripts properly (3PlayMedia streaming enabled).
+        """
         # Arrange
         self.xblock.threeplaymedia_streaming = True
         three_pm_transcripts = [{'id': 'PM1', 'source': '3play-media'}, {'id': 'PM2', 'source': '3play-media'}]
@@ -311,6 +334,9 @@ class VideoXBlockTests(VideoXBlockTestBase):
             fetch_3pm_transcripts_mock,
             get_managed_transcripts_mock
     ):
+        """
+        Test xBlock gets enabled transcripts properly (3PlayMedia streaming disabled).
+        """
         # Arrange
         self.xblock.threeplaymedia_streaming = False
         three_pm_transcripts = [{'id': 'PM1', 'source': '3play-media'}, {'id': 'PM2', 'source': '3play-media'}]

--- a/video_xblock/tests/unit/test_video_xblock_handlers.py
+++ b/video_xblock/tests/unit/test_video_xblock_handlers.py
@@ -12,11 +12,14 @@ from video_xblock.tests.unit.base import VideoXBlockTestBase, arrange_request_mo
 
 class AuthenticateApiHandlerTests(VideoXBlockTestBase):
     """
-    Test cases for `VideoXBlock.authenticate_video_api_handler`
+    Test cases for `VideoXBlock.authenticate_video_api_handler`.
     """
 
     @patch.object(VideoXBlock, 'authenticate_video_api')
     def test_auth_video_api_handler_delegates_call(self, auth_video_api_mock):
+        """
+        Test xBlock's video API authentication works properly.
+        """
         # Arrange
         request_mock = arrange_request_mock('"test-token-123"')  # JSON string
         auth_video_api_mock.return_value = {}, ''
@@ -35,11 +38,14 @@ class AuthenticateApiHandlerTests(VideoXBlockTestBase):
 
 class UploadDefaultTranscriptHandlerTests(VideoXBlockTestBase):
     """
-    Test cases for `VideoXBlock.upload_default_transcript_handler`
+    Test cases for `VideoXBlock.upload_default_transcript_handler`.
     """
 
     @patch('video_xblock.video_xblock.create_reference_name')
     def test_upload_handler_default_transcript_not_in_vtt_case(self, create_reference_name_mock):
+        """
+        Test xBlock's handler for default transcripts uploading.
+        """
         # Arrange
         request_body = """{"label": "test_label","lang": "test_lang","source": "test_source","url": "test_url"}"""
         assert_data = json.loads(request_body)
@@ -64,9 +70,10 @@ class UploadDefaultTranscriptHandlerTests(VideoXBlockTestBase):
             player_mock.download_default_transcript.return_value = test_subs_text
             type(player_mock).default_transcripts_in_vtt = PropertyMock(return_value=False)
 
-        # Act
+            # Act
             response = self.xblock.upload_default_transcript_handler(request_mock)
-        # Assert
+
+            # Assert
             player_mock.download_default_transcript.assert_called_with(
                 assert_data['url'], assert_data['lang']
             )

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -117,11 +117,11 @@ def filter_transcripts_by_source(transcripts, sources=None, exclude=False):
     Filter given transcripts by source attribute.
 
     Arguments:
-        transcripts (iterable): transcripts dicts to be filtered.
+        transcripts (list, generator): transcripts to be filtered.
         sources (list): TranscriptSources filters.
         exclude (str): Type of filtering.
     Returns:
-        filtered transcripts (generator): only those transcript dicts which met the filter condition.
+        filtered transcripts (list, generator): only those transcript dicts which met the filter condition.
     """
     if sources is None:
         sources = [TranscriptSource.DEFAULT]

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -112,13 +112,24 @@ def create_reference_name(lang_label, video_id, source="default"):
     return reference
 
 
-def filter_transcripts_by_source(transcripts, source=TranscriptSource.DEFAULT):
+def filter_transcripts_by_source(transcripts, sources=None, exclude=False):
     """
     Filter given transcripts by source attribute.
+
+    Arguments:
+        transcripts (iterable): transcripts dicts to be filtered.
+        sources (list): TranscriptSources filters.
+        exclude (str): Type of filtering.
+    Returns:
+        filtered transcripts (generator): only those transcript dicts which met the filter condition.
     """
+    if sources is None:
+        sources = [TranscriptSource.DEFAULT]
     if not transcripts:
         return transcripts
-    return (tr for tr in transcripts if tr['source'] == source)
+    if exclude:
+        return (tr for tr in transcripts if tr['source'] not in sources)
+    return (tr for tr in transcripts if tr['source'] in sources)
 
 
 def normalize_transcripts(transcripts):

--- a/video_xblock/utils.py
+++ b/video_xblock/utils.py
@@ -116,10 +116,12 @@ def filter_transcripts_by_source(transcripts, sources=None, exclude=False):
     """
     Filter given transcripts by source attribute.
 
+    Extra `exclude` flag switches filter in opposite (exclusive) mode.
+
     Arguments:
         transcripts (list, generator): transcripts to be filtered.
         sources (list): TranscriptSources filters.
-        exclude (str): Type of filtering.
+        exclude (bool): Type of filtering.
     Returns:
         filtered transcripts (list, generator): only those transcript dicts which met the filter condition.
     """

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -789,9 +789,9 @@ class VideoXBlock(
 
     def get_enabled_managed_transcripts(self):
         """
-        Get `managed transcripts` (not directly streamed, like "3PlayMedia" ones) - e.g. "manual", "default".
+        Get currently enabled in player `managed` transcripts (e.g. "manual", "default").
 
-        :return: (list) transcripts that enabled but not directly streamed
+        :return: (list) transcripts that enabled but not directly streamed.
         """
         try:
             transcripts = json.loads(self.transcripts) if self.transcripts else []

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -2,6 +2,14 @@
 Video XBlock provides a convenient way to embed videos hosted on supported platforms into your course.
 
 All you need to provide is video url, this XBlock does the rest for you.
+
+Some terms could be useful for subject understanding:
+- manual transcripts - which we upload to xBlock from our file system;
+- default transcripts - which are available with a video clip on a video content store service;
+- 3PlayMedia transcripts - those ones which can be fetched from 3-rd-party service (http://www.3playmedia.com/);
+- enabled transcripts - equals to "active", which are available to choose in the player;
+- managed transcripts - those ones we can manage (enable or disable by our choice selectively), for now it equals
+to "manual" + "default".
 """
 
 import datetime
@@ -790,14 +798,14 @@ class VideoXBlock(
 
     def get_enabled_managed_transcripts(self):
         """
-        Get currently enabled in player `managed` transcripts (e.g. "manual", "default").
+        Get currently enabled in player `managed` ("manual" & "default") transcripts.
 
+        Please, for term definitions refer to the module docstring.
         :return: (list) transcripts that enabled but not directly streamed.
         """
         try:
             transcripts = json.loads(self.transcripts) if self.transcripts else []
-            assert isinstance(transcripts, list)
             return normalize_transcripts(transcripts)
-        except (ValueError, AssertionError):
+        except ValueError:
             log.exception("JSON parser can't handle 'self.transcripts' field value: {}".format(self.transcripts))
             return []


### PR DESCRIPTION
Noted section showed 3PlayMedia transcripts after previous 3PlayMedia transcripts usage but default and manual (managed) transcripts should be shown instead. 

Detailed explanation:

We have an accordion which renders transcripts functionality. The upper section renders manual & default transcripts, the bottom one renders streamed 3PlayMedia transcripts.

M&D section has inherited a[ list of enabled transcripts](http://www.awesomescreenshot.com/image/2676218/f4f07c3131386247d61419910bfb0aab).
In the case, you have enabled 3PM transcripts and then you switch to M&D section, you will see that 3PM transcripts are rendered in the list of enabled transcripts. This was natural behavior before accordion refactoring (list included all kinds of enabled transcripts) but now we want to see in enabled transcripts list only those which are manual or default.