### PR TITLE
Quick fix: hide transcript downloading button from student view

### DIFF
--- a/video_xblock/static/html/student_view.html
+++ b/video_xblock/static/html/student_view.html
@@ -15,22 +15,26 @@
 <ul class="wrapper-downloads-custom">
     {% if handout %}
         <li class="video-handout video-download-button-custom">
-            <a href="{{ handout }}" class="download-handout" download="{{ handout_file_name }}">{% trans 'Download Handout' %}</a>
+            <a href="{{ handout }}" class="download-handout" download="{{ handout_file_name }}">
+                {% trans 'Download Handout' %}
+            </a>
         </li>
     {% endif %}
-    {% if download_transcript_allowed and transcripts %}
+    {% if download_transcript_allowed and transcripts and not transcripts_streaming_enabled %}
         <li class="video-transcript video-download-button-custom
             {% if not transcript_download_link %}is-hidden{% endif %}"
             id="download-transcript-button">
             <a  class="download-transcript"
-                href="{{ transcript_download_link }}">{% trans 'Download transcript' %}</a>
+                href="{{ transcript_download_link }}">{% trans 'Download transcript' %}
+            </a>
         </li>
     {% endif %}
     {% if download_video_url %}
         <li class="video-download-button-custom">
             <a href="{{ download_video_url }}" class="download-video" download
                title="{% trans 'Right-click and save link as to download file' %}"
-               target="_blank">{% trans 'Download Video file' %}</a>
+               target="_blank">{% trans 'Download Video file' %}
+            </a>
         </li>
     {% endif %}
 </ul>

--- a/video_xblock/tests/unit/test_video_xblock.py
+++ b/video_xblock/tests/unit/test_video_xblock.py
@@ -120,6 +120,7 @@ class VideoXBlockTests(VideoXBlockTestBase):
         handler_url.side_effect = ['/player/url', '/transcript/download/url']
         route_transcripts.return_value = 'transcripts.vtt'
         self.xblock.get_transcript_download_link = Mock(return_value='/transcript/link.vtt')
+        self.xblock.threeplaymedia_streaming = True
 
         # Act
         student_view = self.xblock.student_view(unused_context_stub)
@@ -130,6 +131,7 @@ class VideoXBlockTests(VideoXBlockTestBase):
             'static/html/student_view.html',
             display_name='Video',
             download_transcript_allowed=False,
+            transcripts_streaming_enabled=True,
             download_video_url=False,
             handout='',
             handout_file_name='',

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -304,6 +304,7 @@ class VideoXBlock(
                 handout=self.handout,
                 transcripts=self.route_transcripts(),
                 download_transcript_allowed=self.download_transcript_allowed,
+                transcripts_streaming_enabled=self.threeplaymedia_streaming,
                 download_video_url=self.get_download_video_url(),
                 handout_file_name=self.get_file_name_from_path(self.handout),
                 transcript_download_link=full_transcript_download_link,


### PR DESCRIPTION
Studio view has boolean switch to allow students download transcripts from student view. If noted switch is enabled the "Download transcript" button appears under the video in student view.

After deep changes of the way in which transcripts are handled now functionality of transcripts downloading doesn't work (deprecated).

Adaptation (reimplementation) of transcripts downloading is a separate advanced task which should consider all current transcripts usage cases (manual, default and streamed 3PlayMedia; single/multiple transcripts).

So, since transcript downloading doesn't work by these changes the "Download transcript" button will be forcibly switched off to keep smooth UX.
