### PR TITLE
Fix Brightcove backend to track player's state

### DIFF
--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -400,7 +400,8 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         )
         js_files = [
             'static/js/base.js',
-            'static/js/videojs/toggle-button.js'
+            'static/js/videojs/toggle-button.js',
+            'static/js/student-view/player-state.js'
         ]
         js_files += [
             'static/js/videojs/videojs-tabindex.js',

--- a/video_xblock/static/js/student-view/player-state.js
+++ b/video_xblock/static/js/student-view/player-state.js
@@ -100,6 +100,7 @@ var PlayerState = function(player, playerState) {
     };
 
     setInitialState(playerState);
+
     player
         .on('timeupdate', saveProgressToLocalStore)
         .on('volumechange', saveState)


### PR DESCRIPTION
BC backend wasn't initiated to save current player's state.