### PR TITLE
Refactor xBlock's fields filling; revert XBLOCK_SETTINGS structure

### DIFF
--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -477,7 +477,7 @@ class PlaybackStateMixin(XBlock):
         transcripts_object = {
             trans['lang']: {'url': trans['url'], 'label': trans['label']}
             for trans in transcripts
-        }
+            }
         state = {
             'captionsLanguage': self.captions_language or self.course_default_language,
             'transcriptsObject': transcripts_object,
@@ -531,28 +531,11 @@ class SettingsMixin(XBlock):
 
     Sample default settings in /edx/app/edxapp/cms.env.json:
     "XBLOCK_SETTINGS": {
-      "example.com": {
-        "3playmedia_api_key": "987654321",
-        "account_id": "1234567890"
-      }
-    }
-
-    In case of enabled microsites (suppose configured "foo" and "bar" microsites) it can be extended to:
-    "XBLOCK_SETTINGS": {
-        "example.com": {
+        "video_xblock": {
             "3playmedia_api_key": "987654321",
             "account_id": "1234567890",
-        },
-        "foo.example.com": {
-            "player_id": "real_player_id",
-        },
-        "bar.example.com": {
-            "3playmedia_api_key": "1234567890",
-            "account_id": "987654321",
         }
     }
-
-    Here above each provided key corresponds to SITE_NAME environment variable value.
     """
 
     @property
@@ -571,37 +554,11 @@ class SettingsMixin(XBlock):
                     "account_id": "1234567890"
                 }
         """
-        site_name = self.get_current_site_name()
-        if not site_name:
+        settings = import_from('django.conf', 'settings')
+        if not hasattr(settings, 'XBLOCK_SETTINGS'):
             return {}
 
-        settings = import_from('django.conf', 'settings')
-        return settings.XBLOCK_SETTINGS.get(site_name, {})
-
-    def populate_default_values(self, submit_data):
-        """
-        Populate unset default values from settings file.
-        """
-        for key, value in self.settings.items():
-            submit_data.setdefault(key, value)
-            # if key is present in submit data but set to empty value:
-            if key in submit_data and not submit_data[key]:
-                submit_data[key] = value
-
-        return submit_data
-
-    def get_current_site_name(self):
-        """
-        Fetch current site domain.
-
-        :return: (unicode) or None
-        """
-        settings = import_from('django.conf', 'settings')
-
-        try:
-            return settings.SITE_NAME
-        except AttributeError:
-            return
+        return settings.XBLOCK_SETTINGS.get('video_xblock', {})
 
 
 class LocationMixin(XBlock):

--- a/video_xblock/static/html/studio-edit-default-transcripts.html
+++ b/video_xblock/static/html/studio-edit-default-transcripts.html
@@ -74,7 +74,7 @@
     {% else %}
       <div class="default-transcripts-status status-error">
         <span class="icon fa fa-remove" aria-hidden="true"></span>
-        {% trans "There're no transcripts to upload." %}
+        {% trans "There are no transcripts to upload." %}
       </div>
       <div class="tip setting-help">
         <!--{{ auth_error_message }} -->

--- a/video_xblock/tests/unit/test_mixins.py
+++ b/video_xblock/tests/unit/test_mixins.py
@@ -295,16 +295,16 @@ class SettingsMixinTests(VideoXBlockTestBase):
         settings_mock.return_value = {'foo': 'bar', 'spam': 'eggs'}
         field_mock = Mock()
         field_mock.name = 'foo'
-        field_mock.default = ''
+        field_mock.default = field_mock._default = ''
 
         # Act
         populated_field = self.xblock.populate_default_value(field_mock)
 
         # Assert
-        self.assertEqual(populated_field.default, 'bar')
+        self.assertEqual(populated_field._default, 'bar')  # pylint: disable=protected-access
 
     @patch.object(VideoXBlock, 'settings', new_callable=PropertyMock)
-    def test_populate_default_value_for_empty_default(self, settings_mock):
+    def test_populate_default_value_for_falsy_value(self, settings_mock):
         """
         Test xBlock fields' default value will be set from json settings.
         """

--- a/video_xblock/tests/unit/test_mixins.py
+++ b/video_xblock/tests/unit/test_mixins.py
@@ -231,12 +231,13 @@ class SettingsMixinTests(VideoXBlockTestBase):
     Test SettingsMixin
     """
     @override_settings(
+        # Arrange
         XBLOCK_SETTINGS={
-            'domain.com': {
+            'video_xblock': {
                 'field1': 'value1',
                 'field2': 'value2'
             },
-            'foo.domain.com': {
+            'other_xblock': {
                 'field1': 'value1foo',
                 'field2': 'value2foo'
             }
@@ -246,78 +247,79 @@ class SettingsMixinTests(VideoXBlockTestBase):
         """
         Test settings property works with enabled microsites.
         """
-        # Arrange
-        with patch.object(self.xblock, 'get_current_site_name') as get_current_site_name_mock:
-            get_current_site_name_mock.return_value = 'foo.domain.com'
+        # Act
+        settings = self.xblock.settings
 
-            # Act
-            settings = self.xblock.settings
-
-            # Assert
-            self.assertEqual(settings, {'field1': 'value1foo', 'field2': 'value2foo'})
+        # Assert
+        self.assertEqual(settings, {'field1': 'value1', 'field2': 'value2'})
 
     @override_settings(
-        XBLOCK_SETTINGS={
-            'domain.com': {
-                'field1': 'value1',
-                'field2': 'value2'
-            },
-        }
+        # Arrange
+        XBLOCK_SETTINGS={}
     )
-    def test_settings_property_with_microsite_disabled(self):
+    def test_settings_property_no_conf(self):
         """
         Test settings property works with enabled microsites.
         """
+        # Act
+        settings = self.xblock.settings
+
+        # Assert
+        self.assertEqual(settings, {})
+
+    @override_settings(
         # Arrange
-        with patch.object(self.xblock, 'get_current_site_name') as get_current_site_name_mock:
-            get_current_site_name_mock.return_value = None  # SITE_NAME env variable isn't set
+        XBLOCK_SETTINGS={
+            'other_xblock': {
+                'field1': 'value1',
+                'field2': 'value2'
+            }
+        }
+    )
+    def test_settings_property_no_video_xblock_conf(self):
+        """
+        Test settings property works without proper configuration.
+        """
+        # Act
+        settings = self.xblock.settings
 
-            # Act
-            settings = self.xblock.settings
-
-            # Assert
-            self.assertEqual(settings, {})
+        # Assert
+        self.assertEqual(settings, {})
 
     @patch.object(VideoXBlock, 'settings', new_callable=PropertyMock)
-    def test_populate_default_values(self, settings_mock):
+    def test_populate_default_value_for_empty_default(self, settings_mock):
         """
-        Test xBlock fields' default values are populated properly.
+        Test xBlock fields' default value will be set from json settings.
         """
         # Arrange
-        settings_mock.return_value = {'foo': 'another bar', 'spam': 'eggs'}
-        xblock_fields_dict = {'foo': 'bar'}
+        settings_mock.return_value = {'foo': 'bar', 'spam': 'eggs'}
+        field_mock = Mock()
+        field_mock.name = 'foo'
+        field_mock.default = ''
 
         # Act
-        populated_xblock_fields = self.xblock.populate_default_values(xblock_fields_dict)
+        populated_field = self.xblock.populate_default_value(field_mock)
 
         # Assert
-        self.assertEqual(populated_xblock_fields, {'foo': 'bar', 'spam': 'eggs'})
+        self.assertEqual(populated_field.default, 'bar')
 
-    @override_settings(
+    @patch.object(VideoXBlock, 'settings', new_callable=PropertyMock)
+    def test_populate_default_value_for_empty_default(self, settings_mock):
+        """
+        Test xBlock fields' default value will be set from json settings.
+        """
         # Arrange
-        SITE_NAME='foo.example.com'
-    )
-    def test_get_current_site_name_success(self):
-        """
-        Test current site name may be fetched.
-        """
-        # Act
-        prefix = self.xblock.get_current_site_name()
-        # Assert
-        self.assertEqual(prefix, 'foo.example.com')
+        settings_mock.return_value = {'foo': 'bar', 'spam': 'eggs'}
+        field_mock = Mock()
+        field_mock.name = 'foo'
+        field_mock.default = False
 
-    @override_settings(
-        # Arrange
-        SITE_NAME=None
-    )
-    def test_get_current_site_name_failure(self):
-        """
-        Test current site name absence handling.
-        """
         # Act
-        prefix = self.xblock.get_current_site_name()
+        populated_field = self.xblock.populate_default_value(field_mock)
+
         # Assert
-        self.assertIsNone(prefix)
+        self.assertFalse(populated_field.default)
+        self.assertIsInstance(populated_field.default, bool)
 
 
 class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inherits-tests

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -379,11 +379,11 @@ class VideoXBlock(
         initial_default_transcripts, transcripts_autoupload_message = self._update_default_transcripts(
             player, transcripts
         )
+        log.debug("Fetched default transcripts: {}".format(initial_default_transcripts))
 
         # Prepare basic_fields and advanced_fields for them to be rendered
         basic_fields = self.prepare_studio_editor_fields(player.basic_fields)
         advanced_fields = self.prepare_studio_editor_fields(player.advanced_fields)
-        log.debug("Fetched default transcripts: {}".format(initial_default_transcripts))
         context = {
             'advanced_fields': advanced_fields,
             'auth_error_message': auth_error_message,
@@ -485,7 +485,6 @@ class VideoXBlock(
                 continue
             if player_class.match(data['href']):
                 data['player_name'] = player_name
-                data = self.populate_default_values(data)
                 log.debug("Submitted player[{}] with data: {}".format(player_name, data))
                 break
 
@@ -533,6 +532,17 @@ class VideoXBlock(
             info['value'] = self.get_path_for(self.handout)
         return info
 
+    def populate_default_value(self, field):
+        """
+        Populate unset default values from settings file.
+        """
+        for key, value in self.settings.items():
+            # if field value is empty and there is json-settings default:
+            if field.name == key and getattr(field, 'default', None) in ['', u'', 'default']:
+                setattr(field, '_default', value)  # pylint: disable=literal-used-as-attribute
+
+        return field
+
     def _make_field_info(self, field_name, field):
         """
         Override and extend data of built-in method.
@@ -567,19 +577,24 @@ class VideoXBlock(
             info = self.initialize_studio_field_info(field_name, field)
         return info
 
-    def prepare_studio_editor_fields(self, fields):
+    def prepare_studio_editor_fields(self, field_names):
         """
         Order xblock fields in studio editor modal.
 
         Arguments:
-            fields (tuple): Names of Xblock fields.
+            field_names (tuple): Names of Xblock fields.
         Returns:
-            made_fields (list): XBlock fields prepared to be rendered in a studio edit modal.
+            prepared_fields (list): XBlock fields prepared to be rendered in a studio edit modal.
         """
-        made_fields = [
-            self._make_field_info(key, self.fields[key]) for key in fields  # pylint: disable=unsubscriptable-object
-        ]
-        return made_fields
+        prepared_fields = []
+        for field_name in field_names:
+            # set default from json XBLOCK_SETTINGS config:
+            populated_field = self.populate_default_value(self.fields[field_name])
+            # make extra field configuration for frontend rendering:
+            field_info = self._make_field_info(field_name, populated_field)
+            prepared_fields.append(field_info)
+
+        return prepared_fields
 
     def get_file_name_from_path(self, field):
         """

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -589,7 +589,9 @@ class VideoXBlock(
         prepared_fields = []
         for field_name in field_names:
             # set default from json XBLOCK_SETTINGS config:
-            populated_field = self.populate_default_value(self.fields[field_name])
+            populated_field = self.populate_default_value(
+                self.fields[field_name]  # pylint:disable=unsubscriptable-object
+            )
             # make extra field configuration for frontend rendering:
             field_info = self._make_field_info(field_name, populated_field)
             prepared_fields.append(field_info)


### PR DESCRIPTION
Made some changes after Bryan notes.

Postponed per-domain XBLOCK_SETTING implementation.
Planned settings structure:
```
"XBLOCK_SETTINGS": {
        "example.com": {
            "3playmedia_api_key": "987654321",
            "account_id": "1234567890",
        },
        "foo.example.com": {
            "player_id": "real_player_id",
        },
        "bar.example.com": {
            "3playmedia_api_key": "1234567890",
            "account_id": "987654321",
        }
    }
```
Reverted to:
```    
"XBLOCK_SETTINGS": {
        "video_xblock": {
            "3playmedia_api_key": "987654321",
            "account_id": "1234567890",
        }
}
```

Refactored xBlock's fields filling by default values from json XBLOCK_SETTINGS configuration.