### PR TITLE
Brightcove backend player v.6 layout fixes

### DIFF
--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -400,13 +400,13 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         )
         js_files = [
             'static/js/base.js',
-            'static/js/videojs/toggle-button.js',
             'static/js/student-view/player-state.js'
         ]
         js_files += [
             'static/js/videojs/videojs-tabindex.js',
+            'static/js/videojs/toggle-button.js',
             'static/js/videojs/videojs-event-plugin.js',
-            'static/js/videojs/brightcove-videojs-init.js'
+            'static/js/videojs/brightcove-videojs-init.js',
         ]
 
         for js_file in js_files:
@@ -415,6 +415,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         frag.add_css(
             self.resource_string('static/css/brightcove.css')
         )
+        log.debug("[get_frag] initialized scripts: %s", js_files)
         return frag
 
     def get_player_html(self, **context):
@@ -422,19 +423,16 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
         Add VideoJS plugins to the context and render player html using base class logic.
         """
         vjs_plugins = [
-            self.resource_string(
-                'static/vendor/js/videojs-offset.min.js'
-            ),
-            self.resource_string('static/js/videojs/videojs-speed-handler.js')
+            'static/vendor/js/videojs-offset.min.js',
+            'static/js/videojs/videojs-speed-handler.js'
         ]
         if context.get('transcripts'):
             vjs_plugins += [
-                self.resource_string(
-                    'static/vendor/js/videojs-transcript.min.js'
-                ),
-                self.resource_string('static/js/videojs/videojs-transcript.js')
+                'static/vendor/js/videojs-transcript.min.js',
+                'static/js/videojs/videojs-transcript.js'
             ]
-        context['vjs_plugins'] = vjs_plugins
+        context['vjs_plugins'] = map(self.resource_string, vjs_plugins)
+        log.debug("[get_player_html] initialized scripts: %s", vjs_plugins)
         return super(BrightcovePlayer, self).get_player_html(**context)
 
     def dispatch(self, _request, suffix):

--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -109,6 +109,7 @@ class TranscriptsMixin(XBlock):
         Arguments:
             transcripts (unicode): Raw transcripts.
         """
+        log.debug("Routing transcripts: 3PM status={}".format(self.threeplaymedia_streaming))
         transcripts = self.get_enabled_transcripts()
         for tran in transcripts:
             if self.threeplaymedia_streaming:

--- a/video_xblock/static/css/brightcove.css
+++ b/video_xblock/static/css/brightcove.css
@@ -517,7 +517,7 @@ body .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
     width: 100px !important;
     left: -30px !important;
 }
-
+/*changes for v6*/
 .display-flex {
     display: flex;
 }
@@ -548,9 +548,9 @@ body .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
     font-size: 2.8em;
 }
 
-.vjs-v6 .vjs-volume-panel.vjs-control.vjs-volume-panel-horizontal {
-    display: flex;
-    align-items: center;
+.vjs-v6.video-js .vjs-mute-control.vjs-vol-0:before,
+.vjs-v6.video-js .vjs-mute-control.vjs-vol-1:before {
+    display: none !important;
 }
 .vjs-v6 .vjs-volume-panel.vjs-control.vjs-volume-panel-horizontal .vjs-button > .vjs-icon-placeholder:before {
     line-height: 2.2;
@@ -560,8 +560,8 @@ body .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
     display: none;
 }
 
-.vjs-v6 div.vjs-volume-control.vjs-control.vjs-volume-horizontal {
-    margin-top: -4px;
+.vjs-v6 .vjs-volume-control.vjs-control.vjs-volume-horizontal {
+    margin-top: 3px;
 }
 
 .video-js.vjs-v6 .vjs-big-play-button .vjs-icon-placeholder:before {
@@ -572,6 +572,73 @@ body .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
     display: none !important;
 }
 
-.vjs-v6 .vjs-menu-content li:first-child {
-    display: none !important;
+/*.vjs-v6 .vjs-menu-content li:first-child {*/
+    /*display: none !important;*/
+/*}*/
+.vjs-v6 .vjs-subs-caps-button.vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button {
+    display: none;
 }
+.vjs-v6.video-js .vjs-fullscreen-control {
+    right: 125px !important;
+}
+.vjs-v6 .fa-quote-left:before,
+.vjs-v6 .vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button.icon.fa.fa-caret-left.vjs-singleton:before,
+.vjs-v6 .vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button.icon.fa.fa-cc.vjs-singleton:before {
+    top: 50%;
+    position: absolute;
+    transform: translate(-50%, -60%);
+    font-size: 16px;
+    left: 50%;
+}
+.vjs-v6 .vjs-custom-caret-button.vjs-menu-button.vjs-menu-button-popup.vjs-button.fa-caret-up ,
+.vjs-v6 button.vjs-custom-caret-button.vjs-menu-button.vjs-menu-button-popup.vjs-button.fa-caret-left:before {
+    display: none !important;
+
+}
+.vjs-v6 .vjs-custom-transcript-button.vjs-menu-button.vjs-menu-button-popup.vjs-button.vjs-control-enabled {
+    right: -4px;
+    background: none;
+}
+
+.vjs-v6 .vjs-workinghover .vjs-menu-button-popup:hover .vjs-menu {
+    left: 3em;
+}
+.vjs-v6 .vjs-subs-caps-button.vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button .vjs-menu-item:not(.vjs-captions-menu-item) {
+    display: none;
+}
+.vjs-v6 .vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button.icon.fa.fa-caret-left.vjs-singleton:hover:before {
+    transform:  translate(-50%, -60%) rotate(90deg);
+}
+.vjs-v6 .vjs-custom-transcript-button.vjs-menu-button.vjs-menu-button-popup.vjs-button {
+    right: 0;
+}
+.vjs-v6 .vjs-menu .vjs-menu-item.vjs-selected {
+    background-color: rgba(115,133,159,.5) !important;
+}
+.video-js .vjs-volume-menu-button.vjs-menu-button {
+    position: relative !important;
+    right: 0 !important;
+}
+.video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 18em !important;
+}
+@media screen and (max-width: 742px) {
+    .video-js .vjs-playback-rate {
+        width: 120px;
+    }
+}
+.vjs-v6.video-js .vjs-control-enabled {
+    background: none;
+    font-size: 10px;
+}
+.vjs-v6.video-js .vjs-control-enabled:before {
+    padding: 0;
+}
+body .vjs-v6.video-js .vjs-custom-caption-button {
+    right: 0 !important;
+}
+div.vjs-control-bar > div.vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button.icon.fa.fa-cc.vjs-singleton:hover .vjs-menu,
+div.vjs-control-bar > div.vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button.icon.fa.fa-quote-left.vjs-singleton:hover .vjs-menu,
+div.vjs-control-bar > div.vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button.icon.fa.fa-cc.vjs-singleton.vjs-control-enabled .vjs-menu {
+     display: none !important;
+ }

--- a/video_xblock/static/css/brightcove.css
+++ b/video_xblock/static/css/brightcove.css
@@ -7,9 +7,6 @@ body {
 .video-js .vjs-dock-text {
     display: none;
 }
-.bc-player-default_default {
-    overflow: visible;
-}
 .video-js .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
     visibility: visible;
     opacity: 1;
@@ -23,9 +20,6 @@ body {
     -webkit-transform: none !important;
     -ms-transform: none !important;
     height: 40px !important;
-}
-.bc-player-default_default .vjs-menu-button-inline:hover, .bc-player-default_default.vjs-no-flex .vjs-menu-button-inline {
-    width: 12em;
 }
 .video-js.vjs-fullscreen .vjs-control-bar {
     margin-bottom: 0px;
@@ -113,7 +107,7 @@ body {
     display: block;
 }
 .video-js .vjs-control:focus, .video-js .vjs-control:focus, .video-js .vjs-control:hover {
-    background-color: #171a1b;
+    background-color: none;
 }
 .video-js .vjs-control:focus, .video-js .vjs-control:focus:before, .video-js .vjs-control:hover:before {
     text-shadow: none;
@@ -164,19 +158,6 @@ body {
 }
 .video-js.vjs-playing .vjs-big-play-button {
     display: none;
-}
-.bc-player-default_default .vjs-big-play-button:active,
-.bc-player-default_default .vjs-big-play-button:focus,
-.bc-player-default_default:active .vjs-big-play-button,
-.bc-player-default_default:hover .vjs-big-play-button.video-js .vjs-big-play-button:focus {
-    outline: 0;
-    border-color: #fff;
-    background-color: #73859f !important;
-    background-color: rgba(115, 133, 159, .5) !important;
-    /*-webkit-transition: none;*/
-    /*-moz-transition: none;*/
-    /*-o-transition: none;*/
-    /*transition: none;*/
 }
 .video-js .vjs-mouse-display, .video-js .vjs-play-progress, .video-js .vjs-volume-level, .vjs-icon-circle,
 .video-js .vjs-play-control,
@@ -324,11 +305,6 @@ body {
     top: 3px;
     color: #e7ecee;
 }
-.bc-player-default_default .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-    width: 41px;
-    left: 30px;
-    background: #171a1b;
-}
 .video-js .roller {
     height: 5px;
     width: 5px;
@@ -363,29 +339,14 @@ body {
     visibility: visible;
     display: block;
 }
-.vjs-mouse.bc-player-default_default .vjs-progress-control:hover .vjs-play-progress.vjs-slider-bar.vjs-keep-tooltips-inside:after {
-    width: 10px;
-}
 .video-js .vjs-time-control {
     font-size: 13px !important;
-}
-.bc-player-default_default .vjs-time-control.vjs-current-time {
-    margin-left: 22px !important;
 }
 .vjs-playback-rate .vjs-playback-rate-value {
     top: 3px !important;
     padding: 2px 0 0 76px;
     color: #e7ecee;
     text-align: left;
-}
-.bc-player-default_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item {
-    font-weight: bold;
-}
-.bc-player-default_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
-    text-shadow: none;
-    color: inherit;
-    background: rgba(115,133,159,.5);
-    border-radius: 0;
 }
 .video-js .vjs-play-control {
     width: 40px;
@@ -523,10 +484,6 @@ body .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
   width: 120px !important;
 }
 
-.display-flex {
-  display: flex;
-}
-
 .vjs-custom-caption-button .vjs-menu .vjs-menu-content li,
 .vjs-custom-transcript-button .vjs-menu .vjs-menu-content li,
 .vjs-playback-rate .vjs-menu .vjs-menu-content li {
@@ -548,4 +505,73 @@ body .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
 
 .vjs-text-track-display div div {
     width: 100% !important;
-} 
+}
+.vjs-v6.video-js .vjs-play-control .vjs-icon-placeholder {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    content: '' !important;
+}
+
+.vjs-menu-content {
+    width: 100px !important;
+    left: -30px !important;
+}
+
+.display-flex {
+    display: flex;
+}
+
+.vjs-v6 .vjs-menu-content .vjs-icon-placeholder::before {
+   display: none;
+}
+
+.vjs-v6 .vjs-fullscreen-control::before {
+    display: none !important;
+}
+.vjs-v6 .vjs-fullscreen-control.vjs-button > .vjs-icon-placeholder:before {
+    line-height: 1.8 !important;
+    font-size: 2.8em;
+}
+
+.vjs-v6 .vjs-subs-caps-button.vjs-button > .vjs-icon-placeholder:before {
+    line-height: 1.4 !important;
+    font-size: 2.8em;
+}
+
+.video-js.vjs-v6 .vjs-play-control:before {
+    display: none;
+}
+
+.video-js.vjs-v6 .vjs-play-control.vjs-button > .vjs-icon-placeholder:before {
+    line-height: 1.8 !important;
+    font-size: 2.8em;
+}
+
+.vjs-v6 .vjs-volume-panel.vjs-control.vjs-volume-panel-horizontal {
+    display: flex;
+    align-items: center;
+}
+.vjs-v6 .vjs-volume-panel.vjs-control.vjs-volume-panel-horizontal .vjs-button > .vjs-icon-placeholder:before {
+    line-height: 2.2;
+}
+
+.video-js.vjs-v6 .vjs-mute-control.vjs-vol-2:before {
+    display: none;
+}
+
+.vjs-v6 div.vjs-volume-control.vjs-control.vjs-volume-horizontal {
+    margin-top: -4px;
+}
+
+.video-js.vjs-v6 .vjs-big-play-button .vjs-icon-placeholder:before {
+    display: none;
+}
+
+.vjs-v6 .vjs-mouse-display .vjs-time-tooltip {
+    display: none !important;
+}
+
+.vjs-v6 .vjs-menu-content li:first-child {
+    display: none !important;
+}

--- a/video_xblock/static/html/brightcove.html
+++ b/video_xblock/static/html/brightcove.html
@@ -1,3 +1,46 @@
+<style>
+.bc-player-{{player_id}}_default {
+    width: 100%;
+    overflow: visible;
+}
+.bc-player- {{player_id}}_default .vjs-menu-button-inline:hover, .bc-player- {{player_id}}_default.vjs-no-flex .vjs-menu-button-inline {
+    width: 12em;
+}
+.bc-player- {{player_id}}_default .vjs-big-play-button:active,
+.bc-player- {{player_id}}_default .vjs-big-play-button:focus,
+.bc-player- {{player_id}}_default:active .vjs-big-play-button,
+.bc-player- {{player_id}}_default:hover .vjs-big-play-button.video-js .vjs-big-play-button:focus {
+    outline: 0;
+    border-color: #fff;
+    background-color: #73859f !important;
+    background-color: rgba(115, 133, 159, .5) !important;
+    /*-webkit-transition: none;*/
+    /*-moz-transition: none;*/
+    /*-o-transition: none;*/
+    /*transition: none;*/
+}
+.bc-player- {{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    width: 41px;
+    left: 30px;
+    background: #171a1b;
+}
+.bc-player- {{player_id}}_default .vjs-time-control.vjs-current-time {
+    margin-left: 22px !important;
+}
+.vjs-mouse.bc-player- {{player_id}}_default .vjs-progress-control:hover .vjs-play-progress.vjs-slider-bar.vjs-keep-tooltips-inside:after {
+    width: 10px;
+}
+.bc-player- {{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item {
+    font-weight: bold;
+}
+.bc-player- {{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
+    text-shadow: none;
+    color: inherit;
+    background: rgba(115,133,159,.5);
+    border-radius: 0;
+}
+</style>
+
 <div class="display-flex">
     <video data-video-id="{{ video_id }}"
         id="{{ video_player_id }}"

--- a/video_xblock/static/html/brightcove.html
+++ b/video_xblock/static/html/brightcove.html
@@ -3,13 +3,13 @@
     width: 100%;
     overflow: visible;
 }
-.bc-player- {{player_id}}_default .vjs-menu-button-inline:hover, .bc-player- {{player_id}}_default.vjs-no-flex .vjs-menu-button-inline {
+.bc-player-{{player_id}}_default .vjs-menu-button-inline:hover, .bc-player- {{player_id}}_default.vjs-no-flex .vjs-menu-button-inline {
     width: 12em;
 }
-.bc-player- {{player_id}}_default .vjs-big-play-button:active,
-.bc-player- {{player_id}}_default .vjs-big-play-button:focus,
-.bc-player- {{player_id}}_default:active .vjs-big-play-button,
-.bc-player- {{player_id}}_default:hover .vjs-big-play-button.video-js .vjs-big-play-button:focus {
+.bc-player-{{player_id}}_default .vjs-big-play-button:active,
+.bc-player-{{player_id}}_default .vjs-big-play-button:focus,
+.bc-player-{{player_id}}_default:active .vjs-big-play-button,
+.bc-player-{{player_id}}_default:hover .vjs-big-play-button.video-js .vjs-big-play-button:focus {
     outline: 0;
     border-color: #fff;
     background-color: #73859f !important;
@@ -19,21 +19,21 @@
     /*-o-transition: none;*/
     /*transition: none;*/
 }
-.bc-player- {{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+.bc-player-{{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
     width: 41px;
     left: 30px;
     background: #171a1b;
 }
-.bc-player- {{player_id}}_default .vjs-time-control.vjs-current-time {
+.bc-player-{{player_id}}_default .vjs-time-control.vjs-current-time {
     margin-left: 22px !important;
 }
-.vjs-mouse.bc-player- {{player_id}}_default .vjs-progress-control:hover .vjs-play-progress.vjs-slider-bar.vjs-keep-tooltips-inside:after {
+.vjs-mouse.bc-player-{{player_id}}_default .vjs-progress-control:hover .vjs-play-progress.vjs-slider-bar.vjs-keep-tooltips-inside:after {
     width: 10px;
 }
-.bc-player- {{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item {
+.bc-player-{{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item {
     font-weight: bold;
 }
-.bc-player- {{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
+.bc-player-{{player_id}}_default .vjs-menu-button-popup .vjs-menu .vjs-menu-item:hover {
     text-shadow: none;
     color: inherit;
     background: rgba(115,133,159,.5);

--- a/video_xblock/static/js/student-view/player-state.js
+++ b/video_xblock/static/js/student-view/player-state.js
@@ -41,10 +41,9 @@ var PlayerState = function(player, playerState) {
         if (stateCurrentTime > 0) {
             player.currentTime(stateCurrentTime);
         }
-        player
-            .volume(state.volume)
-            .muted(state.muted)
-            .playbackRate(state.playbackRate);
+        player.volume(state.volume);
+        player.muted(state.muted);
+        player.playbackRate(state.playbackRate);
         player.captionsLanguage = state.captionsLanguage;  // eslint-disable-line no-param-reassign
         // To switch off transcripts and captions state if doesn`t have transcripts with current captions language
         if (!transcripts[player.captionsLanguage]) {
@@ -101,16 +100,15 @@ var PlayerState = function(player, playerState) {
 
     setInitialState(playerState);
 
-    player
-        .on('timeupdate', saveProgressToLocalStore)
-        .on('volumechange', saveState)
-        .on('ratechange', saveState)
-        .on('play', saveState)
-        .on('pause', saveState)
-        .on('ended', saveState)
-        .on('transcriptstatechanged', saveState)
-        .on('captionstatechanged', saveState)
-        .on('languagechange', saveState);
+    player.on('timeupdate', saveProgressToLocalStore);
+    player.on('volumechange', saveState);
+    player.on('ratechange', saveState);
+    player.on('play', saveState);
+    player.on('pause', saveState);
+    player.on('ended', saveState);
+    player.on('transcriptstatechanged', saveState);
+    player.on('captionstatechanged', saveState);
+    player.on('languagechange', saveState);
 };
 
 domReady(function() {

--- a/video_xblock/static/js/videojs/brightcove-videojs-init.js
+++ b/video_xblock/static/js/videojs/brightcove-videojs-init.js
@@ -4,17 +4,17 @@
 
 domReady(function() {
     'use strict';
+    // Videojs 5/6 shim
+    var registerPlugin = videojs.registerPlugin || videojs.plugin;
+
     var player = videojs(window.videoPlayerId);
     window.videojs = videojs;
-    videojs.plugin('xblockEventPlugin', window.xblockEventPlugin);
+    registerPlugin('xblockEventPlugin', window.xblockEventPlugin);
     player.xblockEventPlugin();
-    videojs.plugin('offset', window.vjsoffset);
 
+    registerPlugin('offset', window.vjsoffset);
     player.offset({
         start: 0, // do not use quotes for these properties for correct plugin work
         end: 0
     });
-
-    videojs.plugin('videoJSSpeedHandler', window.videoJSSpeedHandler);
-    player.videoJSSpeedHandler();
 });

--- a/video_xblock/static/js/videojs/toggle-button.js
+++ b/video_xblock/static/js/videojs/toggle-button.js
@@ -5,6 +5,8 @@
 
 domReady(function() {
     'use strict';
+    // Videojs 5/6 shim;
+    var registerPlugin = videojs.registerPlugin || videojs.plugin;
 
     var MenuItem = videojs.getComponent('MenuItem');
    /**
@@ -12,6 +14,7 @@ domReady(function() {
     */
     var ToggleMenuItem = videojs.extend(MenuItem, {
         constructor: function constructor(player, options) {
+            console.debug("Initiating ToggleMenuItem");
             MenuItem.call(this, player, options);
             this.on('click', this.onClick);
             this.createEl();
@@ -65,9 +68,10 @@ domReady(function() {
     var ToggleButton = videojs.extend(MenuButton, {
         // base class for create buttons for caption and transcripts
         constructor: function constructor(player, options) {
+            console.debug("Initiating ToggleButton");
             this.kind_ = 'captions';
 
-            ClickableComponent.call(this, player, options);
+            MenuButton.call(this, player, options);
 
             if (!this.player_.singleton_menu) {
                 this.update();
@@ -84,7 +88,6 @@ domReady(function() {
             this.on('click', this.onClick);
             this.on('mouseenter', function() {
                 var caretButton = this.$$('.vjs-custom-caret-button', this.el_.parentNode);
-                this.menu.el_.classList.add('is-visible');
                 if (caretButton.length > 0) {
                     caretButton[0].classList.add('fa-caret-up');
                     caretButton[0].classList.remove('fa-caret-left');
@@ -155,13 +158,9 @@ domReady(function() {
     });
 
     var toggleButton = function(options) {
-        if (this.tagAttributes.brightcove !== undefined) {
-            this.controlBar.customControlSpacer.addChild('ToggleButton', options);
-        } else {
-            this.controlBar.addChild('ToggleButton', options);
-        }
+        this.controlBar.addChild('ToggleButton', options);
     };
 
     videojs.registerComponent('ToggleButton', ToggleButton);
-    videojs.plugin('toggleButton', toggleButton);
+    registerPlugin('toggleButton', toggleButton);
 });

--- a/video_xblock/static/js/videojs/toggle-button.js
+++ b/video_xblock/static/js/videojs/toggle-button.js
@@ -14,7 +14,6 @@ domReady(function() {
     */
     var ToggleMenuItem = videojs.extend(MenuItem, {
         constructor: function constructor(player, options) {
-            console.debug("Initiating ToggleMenuItem");
             MenuItem.call(this, player, options);
             this.on('click', this.onClick);
             this.createEl();
@@ -60,7 +59,6 @@ domReady(function() {
     });
 
     var MenuButton = videojs.getComponent('MenuButton');
-    var ClickableComponent = videojs.getComponent('ClickableComponent');
 
    /**
     *  Custom Video.js component responsible for creation of the custom captions/transcripts buttons.
@@ -68,7 +66,6 @@ domReady(function() {
     var ToggleButton = videojs.extend(MenuButton, {
         // base class for create buttons for caption and transcripts
         constructor: function constructor(player, options) {
-            console.debug("Initiating ToggleButton");
             this.kind_ = 'captions';
 
             MenuButton.call(this, player, options);

--- a/video_xblock/static/js/videojs/videojs-event-plugin.js
+++ b/video_xblock/static/js/videojs/videojs-event-plugin.js
@@ -17,6 +17,7 @@
      * @param {Object} options - Plugin options passed in at initialization time.
      */
     function XBlockEventPlugin() {
+        var player = this;
         var previousTime = 0;
         var currentTime = 0;
 
@@ -103,26 +104,26 @@
         };
         this.ready(function() {
             this.logEvent('onReady');
-        })
-            .on('timeupdate', function() {
-                previousTime = currentTime;
-                currentTime = this.currentTime();
-            })
-            .on('ratechange', function() {
-                this.logEvent('onSpeedChange');
-            })
-            .on('play', function() {
-                this.logEvent('onPlay');
-            })
-            .on('pause', function() {
-                this.logEvent('onPause');
-            })
-            .on('ended', function() {
-                this.logEvent('onEnded');
-            })
-            .on('seeked', function() {
-                this.logEvent('onSeek');
-            });
+        });
+        player.on('timeupdate', function () {
+            previousTime = currentTime;
+            currentTime = this.currentTime();
+        });
+        player.on('ratechange', function () {
+            this.logEvent('onSpeedChange');
+        });
+        player.on('play', function () {
+            this.logEvent('onPlay');
+        });
+        player.on('pause', function () {
+            this.logEvent('onPause');
+        });
+        player.on('ended', function () {
+            this.logEvent('onEnded');
+        });
+        player.on('seeked', function () {
+            this.logEvent('onSeek');
+        });
 
         /* TODO Add following events forwarding to Open edX when respective features are implemented
          onShowLanguageMenu, onHideLanguageMenu, onShowTranscript, onHideTranscript, onShowCaptions, onHideCaptions

--- a/video_xblock/static/js/videojs/videojs-event-plugin.js
+++ b/video_xblock/static/js/videojs/videojs-event-plugin.js
@@ -105,23 +105,23 @@
         this.ready(function() {
             this.logEvent('onReady');
         });
-        player.on('timeupdate', function () {
+        player.on('timeupdate', function() {
             previousTime = currentTime;
             currentTime = this.currentTime();
         });
-        player.on('ratechange', function () {
+        player.on('ratechange', function() {
             this.logEvent('onSpeedChange');
         });
-        player.on('play', function () {
+        player.on('play', function() {
             this.logEvent('onPlay');
         });
-        player.on('pause', function () {
+        player.on('pause', function() {
             this.logEvent('onPause');
         });
-        player.on('ended', function () {
+        player.on('ended', function() {
             this.logEvent('onEnded');
         });
-        player.on('seeked', function () {
+        player.on('seeked', function() {
             this.logEvent('onSeek');
         });
 

--- a/video_xblock/static/js/videojs/videojs-speed-handler.js
+++ b/video_xblock/static/js/videojs/videojs-speed-handler.js
@@ -8,6 +8,8 @@
 
 (function() {
     'use strict';
+    // Videojs 5/6 shim;
+    var registerPlugin = videojs.registerPlugin || videojs.plugin;
     /**
         Videojs speed handler
     */
@@ -70,5 +72,5 @@
     }
     // Export plugin to the root
     window.videoJSSpeedHandler = videoJSSpeedHandler;
-    window.videojs.plugin('videoJSSpeedHandler', videoJSSpeedHandler);
+    registerPlugin('videoJSSpeedHandler', videoJSSpeedHandler);
 }).call(this);

--- a/video_xblock/static/js/videojs/videojs-tabindex.js
+++ b/video_xblock/static/js/videojs/videojs-tabindex.js
@@ -31,15 +31,15 @@ domReady(function() {
             var controlsMap = {
                 progressControl: controlBar.progressControl.seekBar.el_,
                 playToggle: controlBar.playToggle.el_,
-                captionsButton: controlBar.captionsButton.el_,
-                volumeMenuButton: controlBar.volumeMenuButton.volumeBar.el_,
+                captionsButton: (controlBar.subtitlesButton || controlBar.subsCapsButton).el_,
+                volumeMenuButton: (controlBar.volumeMenuButton || controlBar.volumePanel.volumeControl).volumeBar.el_,
                 fullscreenToggle: controlBar.fullscreenToggle.el_,
                 playbackRateMenuButton: controlBar.playbackRateMenuButton.el_
             };
             /* eslint-enable vars-on-top */
 
             // Switch off tabIndex for volumeMenuButton and free slot for volumeBar
-            controlBar.volumeMenuButton.el_.tabIndex = -1;
+            (controlBar.volumeMenuButton || controlBar.volumePanel.volumeControl).el_.tabIndex = -1;
 
             controlBarActions.forEach(function(action) {
                 var el = controlsMap[action] || controlBar[action].el_;  // eslint-disable-line vars-on-top

--- a/video_xblock/static/js/videojs/videojs-transcript.js
+++ b/video_xblock/static/js/videojs/videojs-transcript.js
@@ -4,7 +4,6 @@
 domReady(function() {
     'use strict';
 
-    console.log("Initializing transcripts...");
     videojs(window.videoPlayerId).ready(function() {
         var enableTrack = false;
         var player_ = this;

--- a/video_xblock/static/js/videojs/videojs-transcript.js
+++ b/video_xblock/static/js/videojs/videojs-transcript.js
@@ -4,6 +4,7 @@
 domReady(function() {
     'use strict';
 
+    console.log("Initializing transcripts...");
     videojs(window.videoPlayerId).ready(function() {
         var enableTrack = false;
         var player_ = this;

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -305,20 +305,25 @@ class VideoXBlock(
 
         if transcript_download_link:
             full_transcript_download_link = download_transcript_handler_url + transcript_download_link
+
+        context = {
+            'player_url': player_url,
+            'display_name': self.display_name,
+            'usage_id': self.usage_id,
+            'handout': self.handout,
+            'transcripts': self.route_transcripts(),
+            'download_transcript_allowed': self.download_transcript_allowed,
+            'transcripts_streaming_enabled': self.threeplaymedia_streaming,
+            'download_video_url': self.get_download_video_url(),
+            'handout_file_name': self.get_file_name_from_path(self.handout),
+            'transcript_download_link': full_transcript_download_link,
+            'version': __version__
+        }
+        log.debug("[student_view_context]: transcripts %s", context['transcripts'])
         frag = Fragment(
             render_resource(
                 'static/html/student_view.html',
-                player_url=player_url,
-                display_name=self.display_name,
-                usage_id=self.usage_id,
-                handout=self.handout,
-                transcripts=self.route_transcripts(),
-                download_transcript_allowed=self.download_transcript_allowed,
-                transcripts_streaming_enabled=self.threeplaymedia_streaming,
-                download_video_url=self.get_download_video_url(),
-                handout_file_name=self.get_file_name_from_path(self.handout),
-                transcript_download_link=full_transcript_download_link,
-                version=__version__,
+                **context
             )
         )
         frag.add_javascript(resource_string("static/js/student-view/video-xblock.js"))
@@ -813,6 +818,7 @@ class VideoXBlock(
             transcripts = normalize_transcripts(list(self.fetch_available_3pm_transcripts()))
         else:
             transcripts = self.get_enabled_managed_transcripts()
+        log.debug("Getting enabled transcripts: %s", transcripts)
         return transcripts
 
     def get_enabled_managed_transcripts(self):


### PR DESCRIPTION
### Fixed

- Brightcove player layout:
Brightcove player version 6 (videojs v.6 based) has introduced new css-styles and some decent API changes. Those changes made VideoCloud's videos (which are embedded into version 6 Player) usage uncomfortable... After version 6 became default player version in Brightcove Studio this issue has gained weight. 
This patch fixes player controls layout and implicit plugins' work.

Actions to be addressed to make PR to Appsembler possible:
- [x] wait for @otecMuxah final fixes;
- [x] fix js code style to pass codeclimate checks;
- [x] perform review;
- [ ] update Changelog;
- [ ] bump release version up to 0.9.2;