### PR TITLE
Add multiple transcripts downloading

### DIFF
--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -358,7 +358,7 @@ class TranscriptsMixin(XBlock):
         transcript = self.fetch_single_3pm_translation(transcript_data={'id': transcript_id, 'language_id': lang_id})
         if transcript is None:
             return Response()
-        return Response(transcript.content)
+        return Response(transcript.content, content_type='text/vtt')
 
     @XBlock.handler
     def validate_three_play_media_config(self, request, _suffix=''):

--- a/video_xblock/static/css/student-view.css
+++ b/video_xblock/static/css/student-view.css
@@ -35,3 +35,43 @@
     background-color: #1aa1de;
     color: #fff;
 }
+
+/* Transcripts download dropdown button */
+.dropbtn {
+    padding: 5px;
+    font-size: 15px;
+    border: 1px solid #0075b4;
+    background: #fff !important;
+    color: #0075b4;
+    font-weight: 100;
+}
+
+.dropdown {
+    display: inline-block;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+
+.dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+}
+
+.dropdown-content a:hover {background-color: #1aa1de}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+.dropdown:hover .dropbtn {
+    background-color: #0075b4 !important;
+    color: #fff !important;
+}

--- a/video_xblock/static/html/student_view.html
+++ b/video_xblock/static/html/student_view.html
@@ -20,13 +20,21 @@
             </a>
         </li>
     {% endif %}
-    {% if download_transcript_allowed and transcripts and not transcripts_streaming_enabled %}
-        <li class="video-transcript video-download-button-custom
-            {% if not transcript_download_link %}is-hidden{% endif %}"
-            id="download-transcript-button">
-            <a  class="download-transcript"
-                href="{{ transcript_download_link }}">{% trans 'Download transcript' %}
-            </a>
+    {% if download_transcript_allowed and transcripts %}
+        <li class="video-transcript video-download-button-custom" id="download-transcripts-button">
+            <div class="dropdown">
+                <button class="dropbtn">
+                    {% trans 'Download transcripts' %}
+                </button>
+                <div class="dropdown-content">
+                    {% for transcript in transcripts %}
+                    <a href="{{ transcript.url }}"
+                       download="{{ transcript.label|lower }}_{{ transcript.lang }}.vtt">
+                        {{ transcript.label }}
+                    </a>
+                    {% endfor %}
+                </div>
+            </div>
         </li>
     {% endif %}
     {% if download_video_url %}


### PR DESCRIPTION
## Added
- button with multiple links for downloading any attached transcripts (manual, default, 3PM) which appears under the player if xBlock's field `Download Transcript Allowed` is set to `True`.