### PR TITLE
fixed list of components installed by pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,5 @@ setup(
             'html5-player = video_xblock.backends.html5:Html5Player',
         ]
     },
-    package_data=package_data("video_xblock", ["static", ]),
+    package_data=package_data("video_xblock", ["static", "backends", "public", "tests", "workbench"]),
 )


### PR DESCRIPTION
Reason: the package content is broken if installed by 
```pip install git+https://github.com/raccoongang/xblock-video.git```
After installing module directory miss "backends", "public", "tests", "workbench" directories.