### PR TITLE
[CXB-5] Add component location ID in studio edit

### DIFF
--- a/video_xblock/static/html/studio-edit-tab.html
+++ b/video_xblock/static/html/studio-edit-tab.html
@@ -53,6 +53,11 @@
     </li>
 {% endfor %}
 
+<li class="field comp-setting-entry metadata_entry">
+    <label class="label setting-label">Component Location ID</label>
+    <span>{{ usage_id }}</span>
+</li>
+
 {% if name == 'advanced' %}
     {% include 'studio-edit-brightcove-encryption.html' %}
 {% endif %}

--- a/video_xblock/video_xblock.py
+++ b/video_xblock/video_xblock.py
@@ -413,6 +413,7 @@ class VideoXBlock(
             'initial_default_transcripts': initial_default_transcripts,
             'transcripts_autoupload_message': transcripts_autoupload_message,
             'download_transcript_handler_url': download_transcript_handler_url,
+            'usage_id': self.usage_id,
         }
 
         fragment.content = render_template('studio-edit.html', **context)


### PR DESCRIPTION
**Youtrack: ** https://youtrack.raccoongang.com/issue/CXB-5
**Description: ** Add component location ID in studio edit for using xblock-video with In Video Quiz XBlock
Related feature has already implemented in edX - https://github.com/edx/edx-platform/pull/11999