### PR TITLE
[GREENHOST] Fix duplicated progress bars for Vimeo

### DIFF
--- a/video_xblock/static/vendor/js/Vimeo.js
+++ b/video_xblock/static/vendor/js/Vimeo.js
@@ -57,7 +57,7 @@ THE SOFTWARE. */
       this.iframe.setAttribute('id', this.options_.techId);
       this.iframe.setAttribute('title', 'Vimeo Video Player');
       this.iframe.setAttribute('class', 'vimeoplayer');
-      this.iframe.setAttribute('src', this.baseUrl + this.videoId + '?api=1&player_id=' + this.options_.techId);
+      this.iframe.setAttribute('src', this.baseUrl + this.videoId + '?api=1&controls=0&player_id=' + this.options_.techId);
       this.iframe.setAttribute('frameborder', '0');
       this.iframe.setAttribute('scrolling', 'no');
       this.iframe.setAttribute('marginWidth', '0');


### PR DESCRIPTION
**Description:**
- Fix duplicated Vimeo progress bar by adding a new parameter to request `controls=0`

**YouTrack:**
[GREENHOST-198](https://youtrack.raccoongang.com/issue/GREENHOST-198)
