### PR TITLE
Allow Vimeo API-fetched transcripts to be indexed

### DIFF
--- a/video_xblock/backends/vimeo.py
+++ b/video_xblock/backends/vimeo.py
@@ -12,6 +12,7 @@ import requests
 
 from video_xblock import BaseVideoPlayer, ApiClientError
 from video_xblock.backends.base import BaseApiClient
+from video_xblock.constants import TranscriptSource
 from video_xblock.utils import ugettext as _, remove_escaping
 
 log = logging.getLogger(__name__)
@@ -259,6 +260,7 @@ class VimeoPlayer(BaseVideoPlayer):
                     'lang': lang_code,
                     'label': lang_label,
                     'url': t_data["link"],
+                    'source': TranscriptSource.DEFAULT,
                 })
             except KeyError:
                 raise VimeoApiClientError(_('Transcripts API has been changed.'))

--- a/video_xblock/tests/unit/test_backends.py
+++ b/video_xblock/tests/unit/test_backends.py
@@ -449,6 +449,7 @@ class VimeoApiClientTest(VideoXBlockTestBase):
         self.assertEqual(parsed, [{
             'lang': transcripts_data[0][u'language'],
             'label': u'English',
+            'source': TranscriptSource.DEFAULT,
             'url': transcripts_data[0][u'link']
         }])
 


### PR DESCRIPTION
Only transcripts with a source of 'default' or 'manual' are indexed. Fetched transcripts in YouTube are being tagged 'default'; modify vimeo to match.