### PR TITLE
Fix comparison of string and bytestring

### DIFF
--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -106,10 +106,10 @@ class TranscriptsMixin(XBlock):
         """
         text_lines = []
         for line in vtt_content.splitlines():
-            if '-->' in line or line == '':
+            if b'-->' in line or line == b'':
                 continue
             text_lines.append(line)
-        return ' '.join(text_lines)
+        return b' '.join(text_lines)
 
     def route_transcripts(self):
         """


### PR DESCRIPTION
Comparison of string to bytestring raised an error when re-indexing courses that contain video-xblock units.