### PR TITLE
Make some strings b'' so course indexing works

### DIFF
--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -106,10 +106,10 @@ class TranscriptsMixin(XBlock):
         """
         text_lines = []
         for line in vtt_content.splitlines():
-            if '-->' in line or line == '':
+            if b'-->' in line or line == b'':
                 continue
             text_lines.append(line)
-        return ' '.join(text_lines)
+        return b' '.join(text_lines)
 
     def route_transcripts(self):
         """


### PR DESCRIPTION
This change has been lying aroun on our server for a while, so forgive me for not having the error logs. 

We had an error when we were indexing courses for search (`./manage.py cms reindex_library --all` or `./manage.py cms reindex_course --all`). The error was caused by the lines changed here, because `line` is a byte string, and Python3 is a bit more strict on searching for strings in byte strings. 

This patch fixed the error.