### PR TITLE
Bump __version__ to 0.10.4,  update CHANGELOG w missing releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,34 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.4] - 2021-08-05
+
+Released 2021-08-05, fix commit on 2020-09-18
+
+### Fixed
+
+- Fixed rendering of Django templates fails in Ironwood after a video_xblock is rendered
+
+## [0.10.3] - 2018-11-22
+
+### Added
+
+- Fixes for Hawthorn
+
+## [0.10.2] - 2018-07-04
+
+### Fixes
+
+- Fixed list of components installed by pip install
+
 ## [0.10.1] - 2018-02-13
 
-## Added
+### Added
 
 - Multiple transcripts downloading;
 - Error handling during Brightcove video re-transcode job submitting;
 
-## Fixed
+### Fixed
 
 - Safari `empty transcripts` issue;
 - Studio editor improvements:
@@ -23,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.10.0] - 2018-01-24
 
-## Added
+### Added
 
 - Ability to perform search within text tracks (subtitles/transcripts);
 

--- a/video_xblock/__init__.py
+++ b/video_xblock/__init__.py
@@ -2,7 +2,7 @@
 Video xblock module.
 """
 
-__version__ = '0.10.1'
+__version__ = '0.10.4'
 
 # pylint: disable=wildcard-import
 from .video_xblock import *  # nopep8


### PR DESCRIPTION
I'm doing some work on our fork before I prepare a 1.0.0 release with full switch to Python3, some BrightCove and other community fixes.  Just want to get a the releases up to date first.