### PR TITLE
Implement Tencent Video Player Backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             'video_xblock = video_xblock:VideoXBlock',
         ],
         'video_xblock.v1': [
+            'tencent-player = video_xblock.backends.tencent:TencentPlayer',
             'youtube-player = video_xblock.backends.youtube:YoutubePlayer',
             'wistia-player = video_xblock.backends.wistia:WistiaPlayer',
             'brightcove-player = video_xblock.backends.brightcove:BrightcovePlayer',

--- a/video_xblock/backends/base.py
+++ b/video_xblock/backends/base.py
@@ -15,6 +15,7 @@ import re
 from webob import Response
 from xblock.fragment import Fragment
 from xblock.plugin import Plugin
+from xblock.validation import ValidationMessage
 
 from django.conf import settings
 
@@ -71,6 +72,7 @@ class BaseVideoPlayer(Plugin):
     __metaclass__ = abc.ABCMeta
 
     entry_point = 'video_xblock.v1'
+    advanced_tab_enabled = True
 
     def __init__(self, xblock):
         """
@@ -180,6 +182,27 @@ class BaseVideoPlayer(Plugin):
         Return: (bool) if default transcripts fetched already in VTT format.
         """
         return False
+
+    @staticmethod
+    def add_validation_message(validation, message_text):
+        """
+        Add error message on xblock fields validation.
+
+        Attributes:
+            validation (xblock.validation.Validation): Object containing validation information for an xblock instance.
+            message_text (str): Message text per se.
+        """
+        validation.add(ValidationMessage(ValidationMessage.ERROR, message_text))
+
+    def validate_data(self, validation, data):
+        """
+        Validate fields data.
+
+        Attributes:
+            validation (xblock.validation.Validation): Object containing validation information for an xblock instance.
+            data (xblock.internal.VideoXBlockWithMixins): Object containing data on xblock.
+        """
+        pass
 
     def get_frag(self, **context):
         """

--- a/video_xblock/backends/dummy.py
+++ b/video_xblock/backends/dummy.py
@@ -15,6 +15,7 @@ class DummyPlayer(BaseVideoPlayer):
 
     url_re = re.compile(r'')
     advanced_fields = ()
+    advanced_tab_enabled = False
 
     def get_frag(self, **context):  # pylint: disable=unused-argument
         """

--- a/video_xblock/backends/tencent.py
+++ b/video_xblock/backends/tencent.py
@@ -34,7 +34,7 @@ class TencentPlayer(BaseVideoPlayer):
 
         Tencent videos require AppId.
         """
-        return super(TencentPlayer, self).basic_fields + ['app_id']
+        return super().basic_fields + ['app_id']
 
     def validate_data(self, validation, data):
         """
@@ -44,9 +44,8 @@ class TencentPlayer(BaseVideoPlayer):
             validation (xblock.validation.Validation): Object containing validation information for an xblock instance.
             data (xblock.internal.VideoXBlockWithMixins): Object containing data on xblock.
         """
-        # Validate provided app id
+
         if not data.app_id:
-            # AppId field is mandatory
             self.add_validation_message(
                 validation,
                 _("AppID can not be empty. Please provide a valid Tencent AppID.")

--- a/video_xblock/backends/tencent.py
+++ b/video_xblock/backends/tencent.py
@@ -1,0 +1,87 @@
+"""
+Tencent Video player backend.
+"""
+
+import json
+import logging
+import re
+
+from django.utils.translation import get_language
+from xblock.fragment import Fragment
+
+from video_xblock import BaseVideoPlayer
+from video_xblock.utils import ugettext as _
+
+log = logging.getLogger(__name__)
+
+
+class TencentPlayer(BaseVideoPlayer):
+    """
+    TencentPlayer is used for videos hosted on tencent cloud.
+    """
+
+    url_re = re.compile(r'^([0-9]+)$')
+    advanced_fields = []
+    advanced_tab_enabled = False
+    fields_help = {
+        'href': _('Your FileID of the video to be played. E.g. 5285890799710670616'),
+    }
+
+    @property
+    def basic_fields(self):
+        """
+        Tuple of VideoXBlock fields to display in Basic tab of edit modal window.
+
+        Tencent videos require AppId.
+        """
+        return super(TencentPlayer, self).basic_fields + ['app_id']
+
+    def validate_data(self, validation, data):
+        """
+        Validate app id value which is mandatory.
+
+        Attributes:
+            validation (xblock.validation.Validation): Object containing validation information for an xblock instance.
+            data (xblock.internal.VideoXBlockWithMixins): Object containing data on xblock.
+        """
+        # Validate provided app id
+        if not data.app_id:
+            # AppId field is mandatory
+            self.add_validation_message(
+                validation,
+                _("AppID can not be empty. Please provide a valid Tencent AppID.")
+            )
+
+    def media_id(self, href):
+        """
+        Return media_Id
+        """
+        return href
+
+    def get_frag(self, **context):
+        """
+        Return a Fragment required to render video player on the client side.
+        """
+        context['player_state'] = json.dumps(context['player_state'])
+        context['lang_code'] = get_language()
+
+        frag = Fragment(
+            self.render_template('tencent.html', **context)
+        )
+        frag.add_javascript(
+            self.resource_string('static/js/base.js')
+        )
+        frag.add_javascript(
+            self.render_resource('static/js/videojs/tencent-player-init.js', **context)
+        )
+
+        js_urls = [
+            '//cloudcache.tencent-cloud.com/open/qcloud/video/tcplayer/libs/hls.min.0.12.4.js',
+            '//cloudcache.tencent-cloud.com/open/qcloud/video/tcplayer/tcplayer.v4.min.js',
+        ]
+        for js_url in js_urls:
+            frag.add_javascript_url(js_url)
+
+        frag.add_css_url('//cloudcache.tencent-cloud.com/open/qcloud/video/tcplayer/tcplayer.css')
+
+        return frag

--- a/video_xblock/constants.py
+++ b/video_xblock/constants.py
@@ -27,6 +27,7 @@ class PlayerName:
     VIMEO = 'vimeo-player'
     WISTIA = 'wistia-player'
     YOUTUBE = 'youtube-player'
+    TENCENT = 'tencent-player'
 
 
 class TranscriptSource:

--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -230,12 +230,12 @@ class TranscriptsMixin(XBlock):
 
         if feedback['status'] is Status.error:
             log.error("3PlayMedia transcripts fetching API request has failed!\n{}".format(feedback['message']))
-            raise StopIteration
+            return
 
         for transcript_data in transcripts_list:
             transcript = self.fetch_single_3pm_translation(transcript_data)
             if transcript is None:
-                raise StopIteration
+                return
             transcript_ordered_dict = transcript._asdict()
             transcript_ordered_dict['content'] = ''  # we don't want to parse it to JSON
             yield transcript_ordered_dict

--- a/video_xblock/settings_test.py
+++ b/video_xblock/settings_test.py
@@ -1,7 +1,7 @@
 """
 Test settings.
 """
-from django.conf.global_settings import * # pylint: disable=wildcard-import
+from django.conf.global_settings import *  # pylint: disable=wildcard-import
 
 
 # It's needed to specify Django templates backend

--- a/video_xblock/static/html/tencent.html
+++ b/video_xblock/static/html/tencent.html
@@ -1,0 +1,7 @@
+<video id="{{ video_player_id }}"
+    preload="auto"
+    style="width:100%; height:100%"
+    playsinline
+    webkit-playsinline
+    x5-playsinline
+></video>

--- a/video_xblock/static/js/studio-edit/studio-edit.js
+++ b/video_xblock/static/js/studio-edit/studio-edit.js
@@ -8,7 +8,7 @@ languageChecker getHandlers */
     Reference:
         https://github.com/edx/xblock-utils/blob/v1.0.3/xblockutils/templates/studio_edit.html
 */
-function StudioEditableXBlock(runtime, element) {
+function StudioEditableXBlock(runtime, element, context) {
     'use strict';
 
     var fields = [];
@@ -22,7 +22,7 @@ function StudioEditableXBlock(runtime, element) {
     var $availableLabel = $('div.custom-field-section-label.available-transcripts');
     var $modalHeaderTabs = $('.editor-modes.action-list.action-modes');
     var currentTabName;
-    var isNotDummy = $('#xb-field-edit-href').val() !== '';
+    var advancedTabEnabled = context.advancedTabEnabled;
     var SUCCESS = 'success';
     var ERROR = 'error';
 
@@ -64,7 +64,7 @@ function StudioEditableXBlock(runtime, element) {
 
     // Create advanced and basic tabs
     (function() {
-        if (isNotDummy) {
+        if (advancedTabEnabled) {
             $modalHeaderTabs
                 .append(
                     '<li class="inner_tab_wrap">' +

--- a/video_xblock/static/js/videojs/tencent-player-init.js
+++ b/video_xblock/static/js/videojs/tencent-player-init.js
@@ -1,0 +1,13 @@
+/**
+ * This part is responsible for initialization of TCPlayer.
+ */
+
+domReady(function() {
+    'use strict';
+    var player = TCPlayer('{{ video_player_id }}', {
+        fileID: "{{ video_id }}",
+        appID: "{{ app_id }}",
+        psign: "",
+        language: "{{ lang_code }}",
+    });
+});

--- a/video_xblock/tests/unit/test_backends.py
+++ b/video_xblock/tests/unit/test_backends.py
@@ -9,7 +9,7 @@ import requests
 from ddt import ddt, data, unpack
 from django.test.utils import override_settings
 from lxml import etree
-from mock import PropertyMock, Mock, patch
+from mock import PropertyMock, Mock, MagicMock, patch
 from xblock.core import XBlock
 
 from video_xblock.backends import (
@@ -19,7 +19,9 @@ from video_xblock.backends import (
     wistia,
     youtube,
     vimeo,
+    tencent,
 )
+from video_xblock import VideoXBlock
 from video_xblock.constants import TranscriptSource
 from video_xblock.exceptions import VideoXBlockException
 from video_xblock.settings import ALL_LANGUAGES
@@ -56,7 +58,7 @@ class TestCustomBackends(VideoXBlockTestBase):
     """
     Unit tests for custom video xblock backends.
     """
-    backends = ['youtube', 'brightcove', 'wistia', 'vimeo', 'html5']
+    backends = ['youtube', 'brightcove', 'wistia', 'vimeo', 'html5', 'tencent']
 
     auth_mocks = [
         youtube_mock.YoutubeAuthMock,
@@ -82,6 +84,7 @@ class TestCustomBackends(VideoXBlockTestBase):
     @XBlock.register_temp_plugin(youtube.YoutubePlayer, 'youtube')
     @XBlock.register_temp_plugin(vimeo.VimeoPlayer, 'vimeo')
     @XBlock.register_temp_plugin(html5.Html5Player, 'html5')
+    @XBlock.register_temp_plugin(tencent.TencentPlayer, 'tencent')
     def setUp(self):
         super(TestCustomBackends, self).setUp()
         self.player = {}
@@ -109,7 +112,7 @@ class TestCustomBackends(VideoXBlockTestBase):
         for backend in self.backends:
             player = self.player[backend]
             res = player(self.xblock).get_player_html(**context)
-            self.assertIn('window.videojs', res.body.decode())
+            self.assertIn('</video>', res.body.decode())
 
     expected_basic_fields = [
         ['display_name', 'href'],
@@ -117,6 +120,7 @@ class TestCustomBackends(VideoXBlockTestBase):
         ['display_name', 'href'],
         ['display_name', 'href'],
         ['display_name', 'href'],
+        ['display_name', 'href', 'app_id'],
     ]
 
     expected_advanced_fields = [
@@ -140,6 +144,16 @@ class TestCustomBackends(VideoXBlockTestBase):
             'start_time', 'end_time', 'handout',
             'download_transcript_allowed', 'download_video_allowed',
         ],
+        [],  # Tencent
+    ]
+
+    expected_advanced_tab_enabled = [
+        True,  # Brightcove
+        True,  # Wistia
+        True,  # Wistia
+        True,  # Vimeo
+        True,  # Html5
+        False,  # Tencent
     ]
 
     @data(*zip(backends, expected_basic_fields, expected_advanced_fields))
@@ -151,6 +165,30 @@ class TestCustomBackends(VideoXBlockTestBase):
         player = self.player[backend](self.xblock)
         self.assertListEqual(player.basic_fields, expected_basic_fields)
         self.assertListEqual(player.advanced_fields, expected_advanced_fields)
+
+    @patch('xblock.fragment.Fragment.initialize_js')
+    @patch.object(VideoXBlock, 'get_enabled_transcripts')
+    @patch.object(VideoXBlock, '_update_default_transcripts')
+    @patch.object(VideoXBlock, 'get_player')
+    @data(*zip(backends, expected_advanced_tab_enabled))
+    @unpack
+    def test_advanced_tab_enabled(self, backend, expected_advanced_tab_enabled, player_mock, 
+            update_default_transcripts_mock, get_enabled_transcripts, initialize_js_mock):
+        """
+        Test advanced tab visibility for {0} backend
+        """
+        context = {}
+        test_js_context = {
+            'advancedTabEnabled': expected_advanced_tab_enabled,
+        }
+        player = self.player[backend](self.xblock)
+        player_mock.return_value = player
+        self.xblock.runtime.handler_url = Mock()
+        update_default_transcripts_mock.return_value = (
+            ['stub1', 'stub2'], 'Stub auto upload message'
+        )
+        self.xblock.studio_view(context)
+        initialize_js_mock.assert_called_once_with('StudioEditableXBlock', test_js_context)
 
     expected_3pm_fields = [
         ['threeplaymedia_file_id', 'threeplaymedia_apikey', 'threeplaymedia_streaming'],
@@ -922,3 +960,17 @@ class BrightcovePlayerTest(VideoXBlockTestBase):  # pylint: disable=test-inherit
         # Assert
         self.assertEqual(auth_data, {})
         self.assertEqual(error_message, test_message)
+
+    def test_get_brightcove_js_url(self):
+        """
+        Test brightcove.js url generation.
+        """
+        player_id = 123
+        account_id = 321
+        self.assertEqual(
+            self.bc_player.get_js_url(account_id, player_id),
+            "https://players.brightcove.net/{account_id}/{player_id}_default/index.min.js".format(
+                account_id=account_id,
+                player_id=player_id
+            )
+        )

--- a/video_xblock/tests/unit/test_backends.py
+++ b/video_xblock/tests/unit/test_backends.py
@@ -9,7 +9,7 @@ import requests
 from ddt import ddt, data, unpack
 from django.test.utils import override_settings
 from lxml import etree
-from mock import PropertyMock, Mock, MagicMock, patch
+from mock import PropertyMock, Mock, patch
 from xblock.core import XBlock
 
 from video_xblock.backends import (

--- a/video_xblock/tests/unit/test_mixins.py
+++ b/video_xblock/tests/unit/test_mixins.py
@@ -3,7 +3,7 @@ VideoXBlock mixins test cases.
 """
 
 import json
-from collections import Iterable, OrderedDict
+from collections import Iterable
 
 import requests
 from django.test import RequestFactory
@@ -514,7 +514,7 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
             transcripts = list(transcripts_gen)
 
             # Assert:
-            self.assertIsInstance(transcripts[0], OrderedDict)
+            self.assertIsInstance(transcripts[0], dict)
             self.assertSequenceEqual(test_args, list(transcripts[0].keys()))
 
             threepm_transcripts_mock.assert_called_once_with(file_id_mock, apikey_mock)


### PR DESCRIPTION
- MWP version of the [Tencent video player](https://intl.cloud.tencent.com/document/product/266/38098), which provides a simple play of the tencent videos.
- Fixed tests, connected with python3 changes
- Refactoring of `BasePlayer` to have the ability to add own backend's validation messages.

The feature was implemented under the ticket
[HARROW-976](https://youtrack.raccoongang.com/issue/HARROW-976) [Tencent Video Player] Implement Tencent super player video-xblock (#477)
