### PR TITLE
fix: [RGOeX-978] Hide vjs controls and play button from vimeo videos to avoid overlapping with default Vimeo controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix speed dropdown width
 - Fix for videos aspect ratio and responsiveness (all providers)
 - Brightcove subtitles popup fix
+- Remove vjs controls from vimeo videos for avoiding problems with default vimeo controls (RGOeX-978)
 
 ## [1.0.1] - 2021-10-20
 

--- a/video_xblock/static/css/videojs.css
+++ b/video_xblock/static/css/videojs.css
@@ -481,3 +481,8 @@ body {
     height: 100% !important;
     top: 0 !important;
 }
+
+.video-js-vimeo .vjs-big-play-button,
+.video-js-vimeo .vjs-control-bar {
+    display: none !important;
+}

--- a/video_xblock/static/html/vimeo.html
+++ b/video_xblock/static/html/vimeo.html
@@ -1,6 +1,6 @@
 <video
   id="{{ video_player_id }}"
-  class="video-js vjs-default-skin"
+  class="video-js vjs-default-skin video-js-vimeo"
   controls
   data-setup='{{ data_setup }}'
 >


### PR DESCRIPTION
https://youtrack.raccoongang.com/issue/RGOeX-978