### PR TITLE
feat: add support for nutmeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] 2022-09-12
+
 ### Fixed
 - Fix BrightCove styling for players based on video.js v6+ (breaks video.js5 but that's very old now)
 - a11y fix - title on video iframe
@@ -22,6 +24,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Brightcove subtitles popup fix (RGOeX-976)
 - Change color for focused items in the player speed dropdown (RGOeX-1344)
 - Remove vjs controls from vimeo videos for avoiding problems with default vimeo controls (RGOeX-978)
+
+### Added
+
+- Add support for the Nutmeg release [RGOeX-1644](https://youtrack.raccoongang.com/issue/RGOeX-1644)
+  - bump requirements for pycaption and xblock-utils
+  - this requires the edx-platform to update its requirements to use `lxml>=4.9` (current version is `4.5.0`) because of pycaption requirements.
 
 ## [1.0.1] - 2021-10-20
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pycaption==2.0.7
-xblock-utils>=2.1,<3
+pycaption==2.1.0
+xblock-utils>=2.1,<4
 requests>=2.9.1,<3.0.0
 babelfish>=0.5.5,<0.6.0
 XBlock==1.4.0,<2

--- a/setup.py
+++ b/setup.py
@@ -47,17 +47,12 @@ setup(
     packages=[
         'video_xblock',
     ],
-    dependency_links=[
-        # At the moment of writing PyPI hosts outdated version of xblock-utils, hence git
-        # Replace dependency links with numbered versions when it's released on PyPI
-        'git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5',
-    ],
     install_requires=[
-        'pycaption==2.0.7',
+        'pycaption==2.1.0',
         'requests>=2.9.1,<3.0.0',
         'babelfish>=0.5.5,<0.6.0',
         'XBlock>=1.4.0,<2',
-        'xblock-utils>=2.1,<3'
+        'xblock-utils>=2.1,<4'
     ],
     entry_points={
         'xblock.v1': [

--- a/video_xblock/__init__.py
+++ b/video_xblock/__init__.py
@@ -2,7 +2,7 @@
 Video xblock module.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 # pylint: disable=wildcard-import
 from .video_xblock import *  # nopep8


### PR DESCRIPTION
Add support for the Nutmeg release [RGOeX-1644](https://youtrack.raccoongang.com/issue/RGOeX-1644)

Bump requirements for pycaption and xblock-utils

This requires the edx-platform to update its requirements to use `lxml>=4.9` (the current version is `4.5.0`) because of pycaption requirements.
Note: tested maple locally with `lxml=4.9.1` (olive uses this version)

Closes https://github.com/raccoongang/xblock-video/issues/551