### PR TITLE
fix: [RGOeX-1240] save scroll position on exit from fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Brightcove subtitles popup fix (RGOeX-976)
 - Change color for focused items in the player speed dropdown (RGOeX-1344)
 - Remove vjs controls from vimeo videos for avoiding problems with default vimeo controls (RGOeX-978)
+- Save scroll position on exit from video xblock fullscreen mode (RGOeX-1240)
 
 ### Added
 

--- a/video_xblock/backends/base.py
+++ b/video_xblock/backends/base.py
@@ -225,7 +225,7 @@ class BaseVideoPlayer(Plugin):
             'static/js/videojs/videojs-tabindex.js',
             'static/js/videojs/toggle-button.js',
             'static/js/videojs/videojs-event-plugin.js',
-            'static/js/videojs/fullscreen-extends.js'
+            'static/js/videojs/fullscreen-extends.js',
         ]
 
         for js_file in js_files:

--- a/video_xblock/backends/base.py
+++ b/video_xblock/backends/base.py
@@ -224,7 +224,8 @@ class BaseVideoPlayer(Plugin):
         js_files += [
             'static/js/videojs/videojs-tabindex.js',
             'static/js/videojs/toggle-button.js',
-            'static/js/videojs/videojs-event-plugin.js'
+            'static/js/videojs/videojs-event-plugin.js',
+            'static/js/videojs/fullscreen-extends.js'
         ]
 
         for js_file in js_files:

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -433,7 +433,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
             'static/js/videojs/toggle-button.js',
             'static/js/videojs/videojs-event-plugin.js',
             'static/js/videojs/brightcove-videojs-init.js',
-            'static/js/videojs/fullscreen-extends.js'
+            'static/js/videojs/fullscreen-extends.js',
         ]
 
         for js_file in js_files:

--- a/video_xblock/backends/brightcove.py
+++ b/video_xblock/backends/brightcove.py
@@ -433,6 +433,7 @@ class BrightcovePlayer(BaseVideoPlayer, BrightcoveHlsMixin):
             'static/js/videojs/toggle-button.js',
             'static/js/videojs/videojs-event-plugin.js',
             'static/js/videojs/brightcove-videojs-init.js',
+            'static/js/videojs/fullscreen-extends.js'
         ]
 
         for js_file in js_files:

--- a/video_xblock/static/js/videojs/fullscreen-extends.js
+++ b/video_xblock/static/js/videojs/fullscreen-extends.js
@@ -1,0 +1,66 @@
+/**
+ * Update FullscreenToggle component and add the additional listener on toggling video fullscreen.
+ */
+
+(function() {
+    'use strict';
+
+    /**
+     * Helper reports whether or not the document is currently displaying content in fullscreen mode.
+     * @returns {boolean}
+     */
+    function isFullScreen() {
+        if (typeof(document.fullscreenElement) === 'undefined') {
+            if (document.webkitCurrentFullScreenElement == null) return false;
+        }
+
+        return document.fullscreenElement != null;
+    }
+
+    /**
+     * Detect exit from the fullscreen mode and send a message to the parent window
+     * about exiting fullscreen mode.
+     */
+    document.addEventListener('fullscreenchange', function () {
+        if (window.parent !== window.top && !isFullScreen()) {
+            // This is used by the Learning MFE to know about exiting fullscreen mode.
+            // The MFE is then able to respond appropriately and scroll the window to the previous scroll position.
+            window.top.postMessage({
+                type: 'plugin.videoFullScreen',
+                payload: {
+                    open: false
+                }
+            }, '*');
+        }
+    });
+
+    var fullscreenToggle = videojs.getComponent('FullscreenToggle');
+
+    /**
+     * Update the FullscreenToggle component for sending a message to the parent window
+     * about entering fullscreen mode.
+     */
+    var FullscreenToggleExtended = videojs.extend(fullscreenToggle, {
+        handleClick() {
+            if (window.parent !== window.top && !this.player_.isFullscreen()) {
+                // This is used by the Learning MFE to know about entering fullscreen mode.
+                // The MFE is then able to respond appropriately and save the previous window scroll position.
+                window.top.postMessage({
+                    type: 'plugin.videoFullScreen',
+                    payload: {
+                        open: true
+                    }
+                }, '*');
+            }
+
+            if (!this.player_.isFullscreen()) {
+                this.player_.requestFullscreen();
+            } else {
+                this.player_.exitFullscreen();
+            }
+        }
+    });
+
+    // Register the component under the name of the native one to rewrite it
+    videojs.registerComponent('FullscreenToggle', FullscreenToggleExtended);
+}).call(this);


### PR DESCRIPTION
**Description:** save scroll position on exit from video xblock fullscreen mode

**Youtrack:** https://youtrack.raccoongang.com/issue/RGOeX-1240

**Note:**
This PR should be merged after merging the corresponding PR in upstream MEF repos
[maple MFE Learning] https://github.com/openedx/frontend-app-learning/pull/982
[nutmeg MFE Learning] https://github.com/openedx/frontend-app-learning/pull/981
[master MFE Learning] https://github.com/openedx/frontend-app-learning/pull/983