### PR TITLE
fix: error during reading manually added subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Error during reading manually added subtitles [RGOeX-24483]
+
 ## [1.1.1] 2023-01-25
 
 ### Fixed

--- a/video_xblock/mixins.py
+++ b/video_xblock/mixins.py
@@ -105,6 +105,8 @@ class TranscriptsMixin(XBlock):
         Utility method to extract text from WebVTT format transcript.
         """
         text_lines = []
+        if isinstance(vtt_content, bytes):
+            vtt_content = str(vtt_content, 'utf-8')
         for line in vtt_content.splitlines():
             if '-->' in line or line == '':
                 continue

--- a/video_xblock/tests/unit/test_mixins.py
+++ b/video_xblock/tests/unit/test_mixins.py
@@ -450,6 +450,23 @@ class TranscriptsMixinTests(VideoXBlockTestBase):  # pylint: disable=test-inheri
                 self.xblock, 'srt_to_vtt', query='test-trans.srt'
             )
 
+    def test_vtt_to_text(self):
+        """
+        Test utility method to extract text from WebVTT format transcript.
+        
+        Checking if the method works correctly if vtt_content 
+        is a byte data type or vtt_content is a string.
+        """
+        # Act
+        response_byte_to_text = self.xblock.vtt_to_text(b'vtt_content is byte data type')
+        response_text = self.xblock.vtt_to_text('vtt_content is string data type')
+        
+        # Assert
+        self.assertIsInstance(response_byte_to_text, str)
+        self.assertEqual(response_byte_to_text, 'vtt_content is byte data type')
+        self.assertIsInstance(response_text, str)
+        self.assertEqual(response_text, 'vtt_content is string data type')        
+
     @patch('video_xblock.mixins.requests', new_callable=MagicMock)
     @patch.object(VideoXBlock, 'convert_caps_to_vtt')
     def test_srt_to_vtt(self, convert_caps_to_vtt_mock, requests_mock):


### PR DESCRIPTION
## Change description
An error occurs if the `vtt_content` parameter is represented as bytes. Added `vtt_content` data format check. If the data is in bytes, then it is converted to `str`.

### Youtrack
https://youtrack.raccoongang.com/issue/RGOeX-24483

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

### Reviewer
- [x] @dyudyunov 
- [ ] @idegtiarov 

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable