### PR TITLE
fix: [RGOeX-25430] generate a download link for transcript file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- The link to download the subtitle file is missing href to the subtitle file [RGOeX-25430]
 - Error during reading manually added subtitles [RGOeX-24483]
 
 ## [1.1.1] 2023-01-25

--- a/video_xblock/static/html/student_view.html
+++ b/video_xblock/static/html/student_view.html
@@ -29,7 +29,7 @@
                 </a>
                 <div class="dropdown-content">
                     {% for transcript in transcripts %}
-                    <a href="{{ transcript.download_url }}"
+                    <a href="{{ transcript.download_url|default:transcript.url }}"
                        download="{{ transcript.label|lower }}_{{ transcript.lang }}.vtt">
                         {{ transcript.label }}
                     </a>


### PR DESCRIPTION
## Change description
When generating a fragment in the student_view template, the download_url parameter was missing in the context, since this parameter is generated during automatic download to the "X Block" transcription. If you add this file manually, the transcript.url parameter is required for the download link.

## Youtrack:**
https://youtrack.raccoongang.com/issue/RGOeX-25430

## Reviewers:
- [ ] @idegtiarov 
- [x] @dyudyunov 

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
