### PR TITLE
feat: [RGOeX-25454] Add the ability to set start and end times for video playback for the Brightcove player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The link to download the subtitle file is missing href to the subtitle file [RGOeX-25430]
 - Error during reading manually added subtitles [RGOeX-24483]
 
-## Added
+### Added
+- Add the ability to set start and end times for video playback for the Brightcove player [RGOeX-25454]
 - Add base color to edit modal window [xblock-video] (RGOeX-25432)
 - Add base color for subtitles list and player control buttons [xblock-video] (RGOeX-25440)
 

--- a/video_xblock/static/js/context.js
+++ b/video_xblock/static/js/context.js
@@ -3,3 +3,5 @@
  */
 window.videoPlayerId = '{{ video_player_id }}';
 window.playerStateObj = JSON.parse('{{ player_state }}');
+window.playerStartTime = JSON.parse('{{ start_time }}');
+window.playerEndTime = JSON.parse('{{ end_time }}');

--- a/video_xblock/static/js/videojs/brightcove-videojs-init.js
+++ b/video_xblock/static/js/videojs/brightcove-videojs-init.js
@@ -14,7 +14,7 @@ domReady(function() {
 
     registerPlugin('offset', window.vjsoffset);
     player.offset({
-        start: 0, // do not use quotes for these properties for correct plugin work
-        end: 0
+        start: window.playerStartTime,
+        end: window.playerEndTime,
     });
 });


### PR DESCRIPTION
**Description:**
Added ability to set `Video Start Time` and `Video Stop Time` for Brightcove player in Video X-Block advanced settings.

**Youtrack:**
https://youtrack.raccoongang.com/issue/RGOeX-25454

**Reviewers:**
- [ ] @idegtiarov
- [x] @dyudyunov

**Pre-Merge Checklist:**
- [x] Demo status: OK
- [x] All related documentation is updated
