### PR TITLE
feat: [RGOeX-25745] Remove the Default Timed Transcript for HTML 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ## Added
+- Removed the "Default Timed Transcript Functionality" for HTML 5 Video Provider [xblock-video] (RGOeX-25745)
 - Convert transcript file to .vtt format on manual upload [xblock-video] (RGOeX-25759)
 
 ### Fixed

--- a/video_xblock/backends/html5.py
+++ b/video_xblock/backends/html5.py
@@ -86,3 +86,12 @@ class Html5Player(BaseVideoPlayer):
             "playbackRates": [0.5, 1, 1.5, 2],
         })
         return result
+
+    @property
+    def trans_fields(self):
+        """
+        List of VideoXBlock fields to display on `Manual & default transcripts` panel for Html5 Player.
+        """
+        fields = super().trans_fields
+
+        return [field for field in fields if field not in self.exclude_advanced_fields]


### PR DESCRIPTION
**Description:**
Removed "Default Synchronized Transcript Feature" for HTML 5 video provider in advanced settings.

<img width="1600" alt="after-1" src="https://github.com/raccoongang/xblock-video/assets/98233552/28ef481e-4d1c-41e8-965a-134918bc7c2b">

**Youtrack:**
- https://youtrack.raccoongang.com/issue/RGOeX-25745

**Reviewers:**
- [ ] @idegtiarov 
- [x] @dyudyunov 
