### PR TITLE
fix: Incorrect error message when uploading handouts in an unsupported format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- Incorrect error message when uploading handouts in an unsupported format [RGOeX-26044]
 - 500 error during upload hangout file [RGOeX-25995]
 
 ## Added

--- a/video_xblock/static/js/studio-edit/transcripts-manual-upload.js
+++ b/video_xblock/static/js/studio-edit/transcripts-manual-upload.js
@@ -95,7 +95,11 @@ function validateTranscriptFile(event, fieldName, filename, $fileUploader) {
     // We still need to validate file extension, since a user can override an `accept` attribute,
     // that is, choose file of any format to submit through a file upload
     if (isNotAcceptedFormat) {
-        errorMessage += 'Please upload a file of "vtt" or "srt" format only. ';
+        if (fieldName === 'transcripts') {
+            errorMessage += 'Please upload a file of "vtt" or "srt" format only. ';
+        } else {
+            errorMessage += 'Unsupported file type. ';
+        }
         isValid = false;
     }
     if (isNotAcceptedSize) {


### PR DESCRIPTION
### Description
When uploading the handout file for the video block - the file explorer allows you to choose files with unsupported types (e.g. .mk, .sh). When uploading such a file - a validation error is displayed in the UI, but its message contains the wrong text that only .srt or .vtt file could be uploaded which is not true (at least pdf files could be used as a handout):

<img width="950" alt="screen_72" src="https://github.com/raccoongang/xblock-video/assets/98233552/07d4c514-e666-4bf6-9800-57b3269033d9">

After changing the logic:

<img width="1620" alt="screen_71" src="https://github.com/raccoongang/xblock-video/assets/98233552/9daf32ee-1040-4d4d-9772-0f25a482e59d">

### Internal RG ticket (YT):
- https://youtrack.raccoongang.com/issue/RGOeX-26044

### Reviewers
- [ ] @dyudyunov 
- [ ] @idegtiarov 


