### PR TITLE
feat: replace ifequl with if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Progress line width exceeded video player limits (Brightcove) [RGOeX-25758]
 - Incorrect error message when uploading handouts in an unsupported format [RGOeX-26044]
 - 500 error during upload hangout file [RGOeX-25995]
+- Replace `ifequal` with `if` to support Django >= 4
 
 ## Added
 - Add transcripts auto-scrolling on play (RGOeX-26175)

--- a/video_xblock/static/html/studio-edit-token.html
+++ b/video_xblock/static/html/studio-edit-token.html
@@ -14,12 +14,12 @@
     id="xb-field-edit-{{field.name}}"
     value="{{field.value|default_if_none:''}}"
   >
-  {% ifequal player_name players.BRIGHTCOVE %}
+  {% if player_name == players.BRIGHTCOVE %}
     <div class="field-elements-wrapper">
       <button id="video-api-authenticate">
         <span aria-hidden="true"></span>{% trans "Connect to video platform" %}<span class="sr"></span>
       </button>
     </div>
-  {% endifequal %}
+  {% endif %}
   <div class="api-response authenticate status"></div>
 </div>

--- a/video_xblock/static/html/studio-edit-transcripts-accordion.html
+++ b/video_xblock/static/html/studio-edit-transcripts-accordion.html
@@ -30,7 +30,7 @@
   <div class="accordion-panel {% if transcripts_type == '3PM' %}active{% endif %}" id="accordion-panel-3pm">
     {% for field in three_pm_fields %}
       <li
-        class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %} {% ifequal field.type 'boolean' %}is-hidden{% endifequal %}"
+        class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %} {% if field.type == 'boolean' %}is-hidden{% endif %}"
         data-field-name="{{field.name}}"
         data-default="{% if field.type == 'boolean' %}{{ field.default|yesno:'1,0' }}{% else %}{{ field.default|default_if_none:"" }}{% endif %}"
         data-cast="{{field.type}}"


### PR DESCRIPTION
This change simply replace `ifequl` with `if` since the former has been removed since Django 4 ref [1]. 

To reproduce simply try to run/use it, in Quince relase where the platform is using Django 4.

[1]: https://docs.djangoproject.com/en/5.0/releases/4.0/