### PR TITLE
fix[VERA-11]: bump XBlock pin for verawood compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pycaption==2.1.0
 requests>=2.9.1,<3.0.0
 babelfish>=0.6.0
-Xblock>=4.0.1,<5.0.0
+Xblock>=6.0.0,<7.0.0
 django-statici18n>=2.5.0,<3.0.0
 
 -e git+https://github.com/edx/i18n-tools.git@v0.5.3#egg=edx-i18n-tools

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pycaption==2.1.0',
         'requests>=2.9.1,<3.0.0',
         'babelfish>=0.6.0',
-        'Xblock>=4.0.1,<5.0.0',
+        'Xblock>=6.0.0,<7.0.0',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
Old pin required XBlock <5.0.0, but verawood's edx-platform ships XBlock 6.x. This forced pip to downgrade XBlock and broke the platform. Widened the pin to allow 6.x.